### PR TITLE
fix: resolve missing i18n translation keys across all locales

### DIFF
--- a/apps/react-native/src/components/ui/modals/AccountSelectorModal.tsx
+++ b/apps/react-native/src/components/ui/modals/AccountSelectorModal.tsx
@@ -388,7 +388,7 @@ export const AccountSelectorModal = forwardRef<AccountSelectorModalRef, AccountS
                           },
                         ]}
                       >
-                        {t('noAccountsAvailable')}
+                        {t('emptyState.noAccountsAvailable')}
                       </Text>
                     </View>
                   ) : (

--- a/apps/react-native/src/locales/es.json
+++ b/apps/react-native/src/locales/es.json
@@ -5,7 +5,9 @@
     "sendTo": "Enviar a",
     "confirmation": "Confirmación",
     "colorDemo": "Demo de Colores",
-    "nftList": "Lista NFT"
+    "nftList": "Lista NFT",
+    "sending": "Enviando",
+    "send": "Enviar"
   },
   "home": {
     "title": "🏠 Inicio",
@@ -41,13 +43,20 @@
     "scan": "Escanear",
     "send": "Enviar",
     "confirm": "Confirmar",
-    "cancel": "Cancelar"
+    "cancel": "Cancelar",
+    "retry": "Reintentar",
+    "refresh": "Actualizar",
+    "clearSearch": "Limpiar búsqueda",
+    "next": "Siguiente"
   },
   "placeholders": {
     "searchAddress": "Buscar / Pegar dirección",
     "enterAmount": "Ingrese cantidad",
     "selectToken": "Seleccionar token",
-    "selectNFT": "Seleccionar NFT"
+    "selectNFT": "Seleccionar NFT",
+    "searchNFTs": "Buscar NFTs",
+    "searchCollections": "Buscar colecciones",
+    "searchToken": "Buscar Token"
   },
   "validation": {
     "required": "Este campo es obligatorio",
@@ -68,15 +77,24 @@
     "save": "Guardar",
     "delete": "Eliminar",
     "retry": "Reintentar",
+    "refresh": "Actualizar",
+    "clearSearch": "Limpiar búsqueda",
     "switchToLightMode": "Cambiar a modo claro",
-    "switchToDarkMode": "Cambiar a modo oscuro"
+    "switchToDarkMode": "Cambiar a modo oscuro",
+    "unknown": "Desconocido",
+    "item": "Artículo",
+    "items": "Artículos"
   },
   "nft": {
     "collection": "Colección",
     "tokenId": "ID del Token",
     "selectMultiple": "Seleccionar Múltiple",
     "selected": "Seleccionado",
-    "nfts": "NFTs"
+    "nfts": "NFTs",
+    "selectedCount_one": "{{count}} NFT Seleccionado",
+    "selectedCount_other": "{{count}} NFTs Seleccionados",
+    "confirmCount_one": "Confirmar {{count}} NFT",
+    "confirmCount_other": "Confirmar {{count}} NFTs"
   },
   "account": {
     "balance": "Saldo",
@@ -93,6 +111,78 @@
     "fee": "Tarifa de Transacción",
     "coveredByFlowWallet": "Cubierto por Flow Wallet",
     "hash": "Hash de Transacción",
-    "blockHeight": "Altura del Bloque"
+    "blockHeight": "Altura del Bloque",
+    "sendTokens": "Enviar Tokens",
+    "sendNFTs": "Enviar NFTs"
+  },
+  "alerts": {
+    "notice": "Aviso",
+    "error": "Error",
+    "maxNFTSelection": "Solo puedes seleccionar hasta 9 NFTs",
+    "selectAtLeastOneNFT": "Por favor selecciona al menos un NFT"
+  },
+  "messages": {
+    "noSearchResults": "No hay resultados de búsqueda",
+    "noNFTsFound": "No se encontraron NFTs",
+    "noNFTsMatchSearch": "No hay NFTs que coincidan con \"{{search}}\" en esta colección",
+    "collectionEmpty": "Esta colección no contiene ningún NFT",
+    "loadingAccount": "Cargando cuenta...",
+    "noNFTCollectionsFound": "No se encontraron colecciones NFT",
+    "noCollectionsMatchSearch": "No hay colecciones que coincidan con \"{{search}}\"",
+    "noNFTCollectionsForAccount": "No se encontraron colecciones NFT para esta cuenta",
+    "noTokensFound": "No se encontraron tokens",
+    "noTokensAvailable": "No hay tokens disponibles",
+    "noTokensWithBalance": "No se encontraron tokens con saldo",
+    "addressCopied": "Dirección copiada al portapapeles",
+    "failedToCopyAddress": "Error al copiar la dirección",
+    "loading": "Cargando..."
+  },
+  "errors": {
+    "failedToLoadNFTs": "Error al cargar NFTs",
+    "failedToLoadTokens": "Error al cargar tokens",
+    "failedToLoadNFTCollections": "Error al cargar colecciones NFT"
+  },
+  "tabs": {
+    "tokens": "Tokens",
+    "nfts": "NFTs"
+  },
+  "sections": {
+    "myAccounts": "Mis Cuentas",
+    "recent": "Reciente",
+    "addressBook": "Libreta de Direcciones"
+  },
+  "labels": {
+    "fromAccount": "Cuenta de Origen",
+    "toAccount": "Cuenta de Destino",
+    "nfts": "NFTs",
+    "sendNFT": "Enviar NFT",
+    "sendNFTs": "Enviar NFTs",
+    "incompatibleAccount": "Cuenta Incompatible",
+    "learnMore": "Saber más"
+  },
+  "emptyState": {
+    "noResultsFoundTitle": "No se Encontraron Resultados",
+    "noResultsFoundDescription": "No hay cuentas o contactos que coincidan con \"{{query}}\". Prueba con un término de búsqueda diferente.",
+    "noAccountsTitle": "No hay Cuentas",
+    "noAccountsDescription": "Aún no has agregado ninguna cuenta. Crea tu primera cuenta para comenzar.",
+    "noAccountsAvailable": "No hay cuentas disponibles",
+    "noRecentRecipientsTitle": "No hay Destinatarios Recientes",
+    "noRecentRecipientsDescription": "Tus destinatarios recientes aparecerán aquí después de enviar tokens.",
+    "noContactsTitle": "No hay Contactos",
+    "noContactsDescription": "Agrega contactos a tu libreta de direcciones para acceso rápido.",
+    "noDataTitle": "No hay Datos",
+    "noDataDescription": "No hay datos disponibles para esta sección."
+  },
+  "contact": {
+    "unknownContact": "Contacto Desconocido"
+  },
+  "colorDemo": {
+    "lightModeColors": "Colores del Modo Claro",
+    "darkModeColors": "Colores del Modo Oscuro",
+    "switchToDark": "Cambiar a Oscuro",
+    "switchToLight": "Cambiar a Claro",
+    "primaryColors": "Colores Primarios",
+    "text": "Texto",
+    "system": "Sistema"
   }
 }

--- a/apps/react-native/src/locales/ja.json
+++ b/apps/react-native/src/locales/ja.json
@@ -163,6 +163,7 @@
     "noResultsFoundDescription": "「{{query}}」に一致するアカウントや連絡先がありません。別の検索語句を試してください。",
     "noAccountsTitle": "アカウントがありません",
     "noAccountsDescription": "まだアカウントを追加していません。最初のアカウントを作成して開始しましょう。",
+    "noAccountsAvailable": "利用可能なアカウントがありません",
     "noRecentRecipientsTitle": "最近の受信者がありません",
     "noRecentRecipientsDescription": "トークンを送信すると、最近の受信者がここに表示されます。",
     "noContactsTitle": "連絡先がありません",

--- a/apps/react-native/src/locales/ru.json
+++ b/apps/react-native/src/locales/ru.json
@@ -163,6 +163,7 @@
     "noResultsFoundDescription": "Нет аккаунтов или контактов, соответствующих \"{{query}}\". Попробуйте другой поисковый запрос.",
     "noAccountsTitle": "Нет аккаунтов",
     "noAccountsDescription": "Вы еще не добавили ни одного аккаунта. Создайте свой первый аккаунт, чтобы начать.",
+    "noAccountsAvailable": "Нет доступных аккаунтов",
     "noRecentRecipientsTitle": "Нет недавних получателей",
     "noRecentRecipientsDescription": "Ваши недавние получатели появятся здесь после того, как вы отправите токены.",
     "noContactsTitle": "Нет контактов",

--- a/apps/react-native/src/locales/zh.json
+++ b/apps/react-native/src/locales/zh.json
@@ -163,6 +163,7 @@
     "noResultsFoundDescription": "没有账户或联系人与「{{query}}」匹配。请尝试不同的搜索词。",
     "noAccountsTitle": "无账户",
     "noAccountsDescription": "您还没有添加任何账户。创建您的第一个账户开始使用。",
+    "noAccountsAvailable": "没有可用的账户",
     "noRecentRecipientsTitle": "无最近收款人",
     "noRecentRecipientsDescription": "发送代币后，您的最近收款人将显示在这里。",
     "noContactsTitle": "无联系人",


### PR DESCRIPTION
## Summary

- Fix AccountSelectorModal component to use correct translation key path `emptyState.noAccountsAvailable` instead of `noAccountsAvailable`
- Add missing `noAccountsAvailable` key to Chinese, Japanese, and Russian locales
- Complete Spanish translations with comprehensive missing sections including emptyState, alerts, messages, errors, tabs, sections, labels, contact, and colorDemo
- Add missing navigation, button, placeholder, common, and NFT translation keys to Spanish locale
- Ensure consistent translation coverage across all supported languages (en, es, ja, ru, zh)

## Problem Solved

Resolves i18next console warning: `missingKey en translation noAccountsAvailable noAccountsAvailable`

The issue occurred because:
1. `AccountSelectorModal.tsx` was using `t('noAccountsAvailable')` but the key was nested under `emptyState.noAccountsAvailable`
2. Several language files were missing translation keys that existed in the English locale
3. Spanish locale was significantly incomplete with many missing sections

## Changes Made

### Fixed Component Usage
- **AccountSelectorModal.tsx**: Updated translation call from `t('noAccountsAvailable')` to `t('emptyState.noAccountsAvailable')`

### Added Missing Keys
- **Chinese (zh.json)**: Added `noAccountsAvailable` key - "没有可用的账户"
- **Japanese (ja.json)**: Added `noAccountsAvailable` key - "利用可能なアカウントがありません"
- **Russian (ru.json)**: Added `noAccountsAvailable` key - "Нет доступных аккаунтов"

### Completed Spanish Translations (es.json)
- Added complete `emptyState` section (8 keys)
- Extended `navigation` section with missing `sending` and `send` keys
- Extended `buttons` section with `retry`, `refresh`, `clearSearch`, `next`
- Extended `placeholders` section with `searchNFTs`, `searchCollections`, `searchToken`
- Extended `common` section with `refresh`, `clearSearch`, `unknown`, `item`, `items`
- Extended `nft` section with pluralization keys `selectedCount_*`, `confirmCount_*`
- Extended `transaction` section with `sendTokens`, `sendNFTs`
- Added complete `alerts` section (4 keys)
- Added complete `messages` section (14 keys)
- Added complete `errors` section (3 keys)
- Added complete `tabs` section (2 keys)
- Added complete `sections` section (3 keys)
- Added complete `labels` section (7 keys)
- Added complete `contact` section (1 key)
- Added complete `colorDemo` section (7 keys)

## Test Plan

- [x] Verify no more i18next missing key warnings in console
- [x] Test AccountSelectorModal displays proper empty state message
- [x] Verify all language files have consistent translation coverage
- [x] Run lint and typecheck validation
- [x] Confirm proper pluralization handling for NFT counts

🤖 Generated with [Claude Code](https://claude.ai/code)