### PR TITLE
ci: improve Android workflow buildType configuration

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -15,10 +15,11 @@ on:
         description: "Build type (debug|dev|release)"
         default: "release"
         required: true
-      targetRef:
-        description: "Git ref to build (branch/tag)"
-        default: "dev"
-        required: false
+        type: choice
+        options:
+          - debug
+          - dev
+          - release
 
 jobs:
   determine-env:
@@ -73,7 +74,7 @@ jobs:
       - name: Checkout (with submodules)
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.targetRef || github.ref }}
+          ref: ${{ github.ref }}
           fetch-depth: 0
           submodules: recursive
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -6,4 +6,4 @@
 [submodule "apps/react-native/android"]
 	path = apps/react-native/android
 	url = https://github.com/onflow/FRW-Android.git
-	branch = develop
+	branch = dev


### PR DESCRIPTION
## Summary

- Simplified Android workflow configuration by removing the `targetRef` parameter and improving `buildType` selection
- Changed `buildType` to use choice input type with clear options: debug, dev, release  
- Fixed checkout to use `github.ref` instead of potentially confusing `targetRef` parameter
- Updated submodule and Android app references to point to correct branches

## Changes

- **`.github/workflows/android.yml`**:
  - Removed `targetRef` input parameter to simplify workflow usage
  - Changed `buildType` to choice type with explicit options (debug|dev|release)
  - Fixed checkout step to use `github.ref` directly
- **`.gitmodules`** and **`apps/react-native/android`**:
  - Updated branch references to align with current repository structure

## Test Plan

- [x] Build validation passed (`pnpm build:packages`)
- [x] TypeScript validation passed (`pnpm typecheck`) 
- [x] Lint validation passed (`pnpm lint`)
- [ ] Test workflow dispatch with different build types
- [ ] Verify scheduled builds work correctly
- [ ] Confirm submodule checkout works as expected

## Related Issues

Closes #282

🤖 Generated with [Claude Code](https://claude.ai/code)