### PR TITLE
ci: change tag pattern from 'extension' to 'ext'

### DIFF
--- a/.github/workflows/latest-release-tags.yml
+++ b/.github/workflows/latest-release-tags.yml
@@ -5,7 +5,7 @@ on:
     tags:
       - release/ios-*
       - release/android-*
-      - release/extension-*
+      - release/ext-*
   workflow_dispatch:
     inputs:
       release_tag:
@@ -46,7 +46,7 @@ jobs:
             release/android-*)
               latest_tag="android-latest"
               ;;
-            release/extension-*)
+            release/ext-*)
               latest_tag="extension-latest"
               ;;
             *)


### PR DESCRIPTION
Updated tag patterns in the workflow to use 'ext' instead of 'extension'.

## 🔗 Related Issues

Closes #937

Linked automatically from the branch name. If incorrect, edit:

<!-- Examples: -->
<!-- Closes #123 -->
<!-- Fixes #456 -->
<!-- Resolves #789 -->

## 📝 Description

<!-- Describe your changes in detail -->

## 📸 Screenshots/Videos

<!-- Add screenshots or videos if applicable -->
