### PR TITLE
fix: tamagui theme token breaking android

### DIFF
--- a/apps/react-native/src/navigation/AppNavigator.tsx
+++ b/apps/react-native/src/navigation/AppNavigator.tsx
@@ -7,6 +7,9 @@ import {
   SendTokensScreen,
   SendToScreen,
   ReceiveScreen,
+  // Onboarding screens
+  GetStartedScreen,
+  ProfileTypeSelectionScreen,
 } from '@onflow/frw-screens';
 import { useSendStore } from '@onflow/frw-stores';
 import {
@@ -55,6 +58,9 @@ export type RootStackParamList = {
     token?: Record<string, unknown>;
     selectedNFTs?: Record<string, unknown>[];
   };
+  // Onboarding screens
+  GetStarted: undefined;
+  ProfileTypeSelection: undefined;
 };
 
 interface AppNavigatorProps {
@@ -287,6 +293,33 @@ const AppNavigator: React.FC<AppNavigatorProps> = props => {
               component={ReceiveScreen}
               options={{
                 headerTitle: t('navigation.receive'),
+              }}
+            />
+          </Stack.Group>
+
+          {/* Onboarding Screens Group */}
+          <Stack.Group
+            screenOptions={{
+              headerShown: true,
+              headerBackTitle: '', // Ensure no back title text
+              headerBackTitleStyle: { fontSize: 0 }, // Additional fallback
+              headerBackVisible: false, // Hide default back button
+              headerLeft: () => <NavigationBackButton />,
+              headerRight: () => <NavigationCloseButton />,
+            }}
+          >
+            <Stack.Screen
+              name="GetStarted"
+              component={GetStartedScreen}
+              options={{
+                headerShown: false, // First screen doesn't need header
+              }}
+            />
+            <Stack.Screen
+              name="ProfileTypeSelection"
+              component={ProfileTypeSelectionScreen}
+              options={{
+                headerShown: false, // No header for profile type selection
               }}
             />
           </Stack.Group>

--- a/packages/screens/src/onboarding/ProfileTypeSelectionScreen.query.tsx
+++ b/packages/screens/src/onboarding/ProfileTypeSelectionScreen.query.tsx
@@ -68,7 +68,7 @@ export function ProfileTypeSelectionScreen(): React.ReactElement {
 
         {/* Title */}
         <YStack mt="$6" mb="$6">
-          <Text fontSize="30" fontWeight="700" color="$text" textAlign="center" lineHeight={36}>
+          <Text fontSize={30} fontWeight="700" color="$text" textAlign="center" lineHeight={36}>
             {t('onboarding.profileType.welcomeTitle')}
           </Text>
         </YStack>


### PR DESCRIPTION
Closes #373

## 🔗 Related Issues



https://github.com/user-attachments/assets/f3e77a99-c353-4cb5-b578-5601a320ad93

- Add the first 2 onboarding screens to the navigation stack to support native entry point

Linked automatically from the branch name. If incorrect, edit:

<!-- Examples: -->
<!-- Closes #123 -->
<!-- Fixes #456 -->
<!-- Resolves #789 -->

## 📝 Description

<!-- Describe your changes in detail -->

## 📸 Screenshots/Videos

<!-- Add screenshots or videos if applicable -->
