### PR TITLE
fix: add responsive layout support for iPad onboarding screens

### DIFF
--- a/packages/screens/src/onboarding/ConfirmRecoveryPhraseScreen.query.tsx
+++ b/packages/screens/src/onboarding/ConfirmRecoveryPhraseScreen.query.tsx
@@ -8,6 +8,7 @@ import {
   ScrollView,
   AccountCreationLoadingState,
   RecoveryPhraseQuestion,
+  useResponsive,
 } from '@onflow/frw-ui';
 import { generateRandomUsername } from '@onflow/frw-utils';
 import React, { useState, useMemo, useEffect, useLayoutEffect } from 'react';
@@ -66,6 +67,7 @@ export function ConfirmRecoveryPhraseScreen({
   navigation,
 }: ConfirmRecoveryPhraseScreenProps = {}): React.ReactElement {
   const { t } = useTranslation();
+  const { contentMaxWidth } = useResponsive();
   const [selectedAnswers, setSelectedAnswers] = useState<Record<number, string>>({});
   const [isCreatingAccount, setIsCreatingAccount] = useState(false);
   const [progress, setProgress] = useState(0);
@@ -413,61 +415,70 @@ export function ConfirmRecoveryPhraseScreen({
   return (
     <>
       <OnboardingBackground>
-        <YStack flex={1}>
-          <ScrollView flex={1} showsVerticalScrollIndicator={false}>
-            <YStack px="$4" pt="$4">
-              {/* Title and description */}
-              <YStack items="center" mb="$8" gap="$2">
-                <Text fontSize={30} fontWeight="700" color="$text" text="center" lineHeight={36}>
-                  {t('onboarding.confirmRecoveryPhrase.title')}
-                </Text>
-                <Text fontSize="$4" color="$textSecondary" text="center" lineHeight={16} maxW={280}>
-                  {t('onboarding.confirmRecoveryPhrase.description')}
-                </Text>
-              </YStack>
+        <YStack flex={1} items="center">
+          {/* Responsive content container - constrained width on iPad */}
+          <YStack flex={1} w="100%" maxWidth={contentMaxWidth}>
+            <ScrollView flex={1} showsVerticalScrollIndicator={false}>
+              <YStack px="$4" pt="$4">
+                {/* Title and description */}
+                <YStack items="center" mb="$8" gap="$2">
+                  <Text fontSize={30} fontWeight="700" color="$text" text="center" lineHeight={36}>
+                    {t('onboarding.confirmRecoveryPhrase.title')}
+                  </Text>
+                  <Text
+                    fontSize="$4"
+                    color="$textSecondary"
+                    text="center"
+                    lineHeight={16}
+                    maxW={280}
+                  >
+                    {t('onboarding.confirmRecoveryPhrase.description')}
+                  </Text>
+                </YStack>
 
-              {/* All questions */}
-              <YStack gap="$8">
-                {questions.map((question, index) => (
-                  <RecoveryPhraseQuestion
-                    key={index}
-                    position={question.position}
-                    options={question.options}
-                    selectedAnswer={selectedAnswers[index]}
-                    correctAnswer={question.correctAnswer}
-                    onSelectWord={handleSelectWord(index)}
-                    questionLabel={t('onboarding.confirmRecoveryPhrase.selectWord', {
-                      position: question.position,
-                    })}
-                  />
-                ))}
+                {/* All questions */}
+                <YStack gap="$8">
+                  {questions.map((question, index) => (
+                    <RecoveryPhraseQuestion
+                      key={index}
+                      position={question.position}
+                      options={question.options}
+                      selectedAnswer={selectedAnswers[index]}
+                      correctAnswer={question.correctAnswer}
+                      onSelectWord={handleSelectWord(index)}
+                      questionLabel={t('onboarding.confirmRecoveryPhrase.selectWord', {
+                        position: question.position,
+                      })}
+                    />
+                  ))}
+                </YStack>
               </YStack>
-            </YStack>
-          </ScrollView>
+            </ScrollView>
 
-          {/* Finish button - matching other screens style */}
-          <YStack px="$4" pb="$6">
-            <YStack
-              width="100%"
-              height={52}
-              bg={!allAnswersCorrect ? '$bg3' : '$text'}
-              rounded={16}
-              items="center"
-              justify="center"
-              borderWidth={1}
-              borderColor={!allAnswersCorrect ? '$bg3' : '$text'}
-              opacity={!allAnswersCorrect ? 0.7 : 1}
-              pressStyle={{ opacity: 0.9 }}
-              onPress={!allAnswersCorrect ? undefined : handleFinish}
-              cursor={!allAnswersCorrect ? 'not-allowed' : 'pointer'}
-            >
-              <Text
-                fontSize="$4"
-                fontWeight="700"
-                color={!allAnswersCorrect ? '$textSecondary' : '$bg'}
+            {/* Finish button - matching other screens style */}
+            <YStack px="$4" pb="$6">
+              <YStack
+                width="100%"
+                height={52}
+                bg={!allAnswersCorrect ? '$bg3' : '$text'}
+                rounded={16}
+                items="center"
+                justify="center"
+                borderWidth={1}
+                borderColor={!allAnswersCorrect ? '$bg3' : '$text'}
+                opacity={!allAnswersCorrect ? 0.7 : 1}
+                pressStyle={{ opacity: 0.9 }}
+                onPress={!allAnswersCorrect ? undefined : handleFinish}
+                cursor={!allAnswersCorrect ? 'not-allowed' : 'pointer'}
               >
-                {t('onboarding.confirmRecoveryPhrase.finish')}
-              </Text>
+                <Text
+                  fontSize="$4"
+                  fontWeight="700"
+                  color={!allAnswersCorrect ? '$textSecondary' : '$bg'}
+                >
+                  {t('onboarding.confirmRecoveryPhrase.finish')}
+                </Text>
+              </YStack>
             </YStack>
           </YStack>
         </YStack>

--- a/packages/screens/src/onboarding/GetStartedScreen.query.tsx
+++ b/packages/screens/src/onboarding/GetStartedScreen.query.tsx
@@ -1,6 +1,13 @@
 import { logger, navigation } from '@onflow/frw-context';
 import { ScreenName } from '@onflow/frw-types';
-import { YStack, Text, Button, OnboardingBackground, OnboardingHeader } from '@onflow/frw-ui';
+import {
+  YStack,
+  Text,
+  Button,
+  OnboardingBackground,
+  OnboardingHeader,
+  useResponsive,
+} from '@onflow/frw-ui';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Linking } from 'react-native';
@@ -15,6 +22,7 @@ const PRIVACY_POLICY_URL = 'https://wallet.flow.com/privacy-policy';
 
 export function GetStartedScreen(): React.ReactElement {
   const { t } = useTranslation();
+  const { contentMaxWidth } = useResponsive();
 
   const handleCreateAccount = () => {
     // Navigate to profile type selection for create account flow
@@ -54,61 +62,64 @@ export function GetStartedScreen(): React.ReactElement {
 
   return (
     <OnboardingBackground variant="getStarted">
-      <YStack flex={1} paddingHorizontal="$4">
-        {/* Top spacer to position title in upper third */}
-        <YStack flex={1} />
+      <YStack flex={1} px="$4" items="center">
+        {/* Responsive content container - constrained width on iPad */}
+        <YStack flex={1} w="100%" maxWidth={contentMaxWidth}>
+          {/* Top spacer to position title in upper third */}
+          <YStack flex={1} />
 
-        {/* Main content */}
-        <YStack alignItems="center" gap="$4">
-          <OnboardingHeader
-            title={t('onboarding.getStarted.title')}
-            subtitle={t('onboarding.getStarted.subtitle')}
-            logoText={t('onboarding.flowWallet')}
-          />
-        </YStack>
+          {/* Main content */}
+          <YStack items="center" gap="$4">
+            <OnboardingHeader
+              title={t('onboarding.getStarted.title')}
+              subtitle={t('onboarding.getStarted.subtitle')}
+              logoText={t('onboarding.flowWallet')}
+            />
+          </YStack>
 
-        {/* Larger spacer to push buttons to bottom */}
-        <YStack flex={2} />
+          {/* Larger spacer to push buttons to bottom */}
+          <YStack flex={2} />
 
-        {/* Bottom buttons */}
-        <YStack paddingBottom="$6" gap="$3">
-          {/* Create Account Button - Primary */}
-          <Button variant="inverse" size="large" fullWidth onPress={handleCreateAccount}>
-            {t('onboarding.getStarted.createAccount')}
-          </Button>
+          {/* Bottom buttons */}
+          <YStack pb="$6" gap="$3">
+            {/* Create Account Button - Primary */}
+            <Button variant="inverse" size="large" fullWidth onPress={handleCreateAccount}>
+              {t('onboarding.getStarted.createAccount')}
+            </Button>
 
-          {/* Sign In Button - Outline */}
-          <Button variant="outline" size="large" fullWidth onPress={handleSignIn}>
-            {t('onboarding.getStarted.signIn')}
-          </Button>
+            {/* Sign In Button - Outline */}
+            <Button variant="outline" size="large" fullWidth onPress={handleSignIn}>
+              {t('onboarding.getStarted.signIn')}
+            </Button>
 
-          <YStack marginTop="$2" alignItems="center" paddingHorizontal="$4">
-            <Text fontSize="$3" color="$textSecondary" lineHeight={17} textAlign="center">
-              {t('onboarding.getStarted.agreementText')}{' '}
-              <Text
-                fontSize="$3"
-                color="$textSecondary"
-                lineHeight={17}
-                textDecorationLine="underline"
-                onPress={handleOpenTerms}
-                cursor="pointer"
-                pressStyle={{ opacity: 0.7 }}
-              >
-                {t('onboarding.getStarted.termsOfService')}
-              </Text>{' '}
-              {t('onboarding.getStarted.and')}{' '}
-              <Text
-                fontSize="$3"
-                color="$textSecondary"
-                lineHeight={17}
-                textDecorationLine="underline"
-                onPress={handleOpenPrivacy}
-                cursor="pointer"
-                pressStyle={{ opacity: 0.7 }}
-              >
-                {t('onboarding.getStarted.privacyPolicy')}
+            <YStack mt="$2" items="center" px="$4">
+              <Text fontSize="$3" color="$textSecondary" lineHeight={17} text="center">
+                {t('onboarding.getStarted.agreementText')}{' '}
+                <Text
+                  fontSize="$3"
+                  color="$textSecondary"
+                  lineHeight={17}
+                  textDecorationLine="underline"
+                  onPress={handleOpenTerms}
+                  cursor="pointer"
+                  pressStyle={{ opacity: 0.7 }}
+                >
+                  {t('onboarding.getStarted.termsOfService')}
+                </Text>{' '}
+                {t('onboarding.getStarted.and')}{' '}
+                <Text
+                  fontSize="$3"
+                  color="$textSecondary"
+                  lineHeight={17}
+                  textDecorationLine="underline"
+                  onPress={handleOpenPrivacy}
+                  cursor="pointer"
+                  pressStyle={{ opacity: 0.7 }}
+                >
+                  {t('onboarding.getStarted.privacyPolicy')}
+                </Text>
               </Text>
-            </Text>
+            </YStack>
           </YStack>
         </YStack>
       </YStack>

--- a/packages/screens/src/onboarding/NotificationPreferencesScreen.query.tsx
+++ b/packages/screens/src/onboarding/NotificationPreferencesScreen.query.tsx
@@ -8,6 +8,7 @@ import {
   OnboardingBackground,
   Image,
   pushNotifications,
+  useResponsive,
 } from '@onflow/frw-ui';
 import { useMutation } from '@tanstack/react-query';
 import React, { useMemo } from 'react';
@@ -65,6 +66,7 @@ export function NotificationPreferencesScreen({
   route,
 }: NotificationPreferencesScreenProps = {}): React.ReactElement {
   const { t } = useTranslation();
+  const { contentMaxWidth, animationScale } = useResponsive();
   const [isCheckingPermission, setIsCheckingPermission] = React.useState(true);
   const safeAreaInsets = useMemo(() => {
     return bridge.getSafeAreaInsets?.() ?? { top: 0, bottom: 0, left: 0, right: 0 };
@@ -184,40 +186,48 @@ export function NotificationPreferencesScreen({
 
   return (
     <OnboardingBackground>
-      <YStack flex={1} px="$4" pt={safeAreaInsets.top + 20} justify="space-between">
-        {/* Title and description */}
-        <YStack mt="$6" mb="$6">
-          <Text fontSize={28} fontWeight="700" color="$text" text="center">
-            {t('onboarding.notificationPreferences.title')}
-          </Text>
+      <YStack flex={1} px="$4" pt={safeAreaInsets.top + 20} items="center" justify="space-between">
+        {/* Responsive content container - constrained width on iPad */}
+        <YStack flex={1} w="100%" maxWidth={contentMaxWidth} justify="space-between">
+          {/* Title and description */}
+          <YStack mt="$6" mb="$6">
+            <Text fontSize={28} fontWeight="700" color="$text" text="center">
+              {t('onboarding.notificationPreferences.title')}
+            </Text>
 
-          <Text fontSize="$4" color="$textSecondary" text="center" px="$2">
-            {t('onboarding.notificationPreferences.subtitle')}
-          </Text>
-        </YStack>
-
-        {/* Notification Preview Image - centered */}
-        <YStack flex={1} items="center" justify="center">
-          <Image source={pushNotifications} width={375} height={492} objectFit="contain" />
-        </YStack>
-
-        {/* Action buttons */}
-        <YStack>
-          {/* Turn on notifications button - Primary style */}
-          <YStack mb="$3">
-            <Button variant="inverse" size="large" fullWidth onPress={handleEnableNotifications}>
-              {t('onboarding.notificationPreferences.enableButton')}
-            </Button>
+            <Text fontSize="$4" color="$textSecondary" text="center" px="$2">
+              {t('onboarding.notificationPreferences.subtitle')}
+            </Text>
           </YStack>
 
-          {/* Maybe later button - Ghost style, centered like secure enclave profile */}
-          <XStack justify="center" pb="$8">
-            <Button variant="ghost" onPress={handleMaybeLater}>
-              <Text fontSize="$4" fontWeight="600" color="$textSecondary">
-                {t('onboarding.notificationPreferences.maybeLater')}
-              </Text>
-            </Button>
-          </XStack>
+          {/* Notification Preview Image - centered and scaled for iPad */}
+          <YStack flex={1} items="center" justify="center">
+            <Image
+              source={pushNotifications}
+              width={Math.round(375 * animationScale)}
+              height={Math.round(492 * animationScale)}
+              objectFit="contain"
+            />
+          </YStack>
+
+          {/* Action buttons */}
+          <YStack>
+            {/* Turn on notifications button - Primary style */}
+            <YStack mb="$3">
+              <Button variant="inverse" size="large" fullWidth onPress={handleEnableNotifications}>
+                {t('onboarding.notificationPreferences.enableButton')}
+              </Button>
+            </YStack>
+
+            {/* Maybe later button - Ghost style, centered like secure enclave profile */}
+            <XStack justify="center" pb="$8">
+              <Button variant="ghost" onPress={handleMaybeLater}>
+                <Text fontSize="$4" fontWeight="600" color="$textSecondary">
+                  {t('onboarding.notificationPreferences.maybeLater')}
+                </Text>
+              </Button>
+            </XStack>
+          </YStack>
         </YStack>
       </YStack>
     </OnboardingBackground>

--- a/packages/screens/src/onboarding/ProfileTypeSelectionScreen.query.tsx
+++ b/packages/screens/src/onboarding/ProfileTypeSelectionScreen.query.tsx
@@ -10,6 +10,7 @@ import {
   ShieldAnimation,
   IconButton,
   useTheme,
+  useResponsive,
 } from '@onflow/frw-ui';
 import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -26,6 +27,7 @@ import { useTranslation } from 'react-i18next';
 export function ProfileTypeSelectionScreen(): React.ReactElement {
   const { t } = useTranslation();
   const theme = useTheme();
+  const { contentMaxWidth, animationScale } = useResponsive();
 
   // Get safe area insets for proper positioning across platforms
   const safeAreaInsets = useMemo(() => {
@@ -58,61 +60,69 @@ export function ProfileTypeSelectionScreen(): React.ReactElement {
 
   return (
     <OnboardingBackground>
-      <YStack flex={1} px="$4" pt="$0">
-        {/* Custom back button - uses safe area insets for proper positioning */}
-        <YStack pt={safeAreaInsets.top}>
-          <IconButton
-            icon={<ArrowLeft color={theme.text.val} size={24} width={24} height={24} />}
-            variant="ghost"
-            size="medium"
-            onPress={handleBack}
-            ml="$2"
-            pt="$4"
-          />
-        </YStack>
+      <YStack flex={1} px="$4" pt="$0" items="center">
+        {/* Responsive content container - constrained width on iPad */}
+        <YStack flex={1} w="100%" maxWidth={contentMaxWidth}>
+          {/* Custom back button - uses safe area insets for proper positioning */}
+          <YStack pt={safeAreaInsets.top}>
+            <IconButton
+              icon={<ArrowLeft color={theme.text.val} size={24} width={24} height={24} />}
+              variant="ghost"
+              size="medium"
+              onPress={handleBack}
+              ml="$2"
+              pt="$4"
+            />
+          </YStack>
 
-        {/* Title */}
-        <YStack mt="$6" mb="$6">
-          <Text fontSize={30} fontWeight="700" color="$text" textAlign="center" lineHeight={36}>
-            {t('onboarding.profileType.welcomeTitle')}
-          </Text>
-        </YStack>
-
-        {/* Shield Animation */}
-        <YStack alignItems="center" mb="$8">
-          <ShieldAnimation width={300} height={375} autoPlay={true} loop={true} />
-        </YStack>
-
-        {/* Recovery phrase description */}
-        <YStack alignItems="center" mb="$8">
-          <YStack maxWidth={307} px="$4" alignItems="center" gap="$2">
-            <Text fontSize="$5" fontWeight="700" color="$text" textAlign="center" mb="$2">
-              {t('onboarding.profileType.recoveryPhrase.title')}
-            </Text>
-            <Text fontSize="$4" color="$textSecondary" textAlign="center" lineHeight={17}>
-              {t('onboarding.profileType.recoveryPhrase.description')}
+          {/* Title */}
+          <YStack mt="$6" mb="$6">
+            <Text fontSize={30} fontWeight="700" color="$text" text="center" lineHeight={36}>
+              {t('onboarding.profileType.welcomeTitle')}
             </Text>
           </YStack>
+
+          {/* Shield Animation - scaled for iPad */}
+          <YStack items="center" mb="$8">
+            <ShieldAnimation
+              width={Math.round(300 * animationScale)}
+              height={Math.round(375 * animationScale)}
+              autoPlay={true}
+              loop={true}
+            />
+          </YStack>
+
+          {/* Recovery phrase description */}
+          <YStack items="center" mb="$8">
+            <YStack maxWidth={307} px="$4" items="center" gap="$2">
+              <Text fontSize="$5" fontWeight="700" color="$text" text="center" mb="$2">
+                {t('onboarding.profileType.recoveryPhrase.title')}
+              </Text>
+              <Text fontSize="$4" color="$textSecondary" text="center" lineHeight={17}>
+                {t('onboarding.profileType.recoveryPhrase.description')}
+              </Text>
+            </YStack>
+          </YStack>
+
+          {/* Spacer */}
+          <YStack flex={1} />
+
+          {/* Next button */}
+          <YStack mb="$3">
+            <Button variant="inverse" size="large" fullWidth onPress={handleNext}>
+              {t('onboarding.profileType.next')}
+            </Button>
+          </YStack>
+
+          {/* Secure enclave link */}
+          <XStack justify="center" pb="$8">
+            <Button variant="ghost" onPress={handleSecureEnclave}>
+              <Text fontSize="$4" fontWeight="600" color="$textSecondary">
+                {t('onboarding.profileType.secureEnclaveProfile')}
+              </Text>
+            </Button>
+          </XStack>
         </YStack>
-
-        {/* Spacer */}
-        <YStack flex={1} />
-
-        {/* Next button */}
-        <YStack mb="$3">
-          <Button variant="inverse" size="large" fullWidth onPress={handleNext}>
-            {t('onboarding.profileType.next')}
-          </Button>
-        </YStack>
-
-        {/* Secure enclave link */}
-        <XStack justifyContent="center" pb="$8">
-          <Button variant="ghost" onPress={handleSecureEnclave}>
-            <Text fontSize="$4" fontWeight="600" color="$textSecondary">
-              {t('onboarding.profileType.secureEnclaveProfile')}
-            </Text>
-          </Button>
-        </XStack>
       </YStack>
     </OnboardingBackground>
   );

--- a/packages/screens/src/onboarding/RecoveryPhraseScreen.query.tsx
+++ b/packages/screens/src/onboarding/RecoveryPhraseScreen.query.tsx
@@ -10,6 +10,7 @@ import {
   AccountCreationLoadingState,
   WarningCard,
   useTheme,
+  useResponsive,
 } from '@onflow/frw-ui';
 import React, { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -39,6 +40,7 @@ interface PhraseData {
 export function RecoveryPhraseScreen(): React.ReactElement {
   const { t } = useTranslation();
   const theme = useTheme();
+  const { contentMaxWidth } = useResponsive();
   const [copiedToClipboard, setCopiedToClipboard] = useState(false);
   const [isPhraseRevealed, setIsPhraseRevealed] = useState(false);
   const [isGenerating, setIsGenerating] = useState(true);
@@ -177,21 +179,23 @@ export function RecoveryPhraseScreen(): React.ReactElement {
     return (
       <OnboardingBackground>
         <YStack flex={1} items="center" justify="center" px="$4" gap="$4">
-          <Text color="$error" text="center" fontSize="$5" fontWeight="700">
-            {t('onboarding.recoveryPhrase.error.title')}
-          </Text>
-          <Text color="$textSecondary" text="center" fontSize="$4">
-            {generateError instanceof Error
-              ? generateError.message
-              : t('onboarding.recoveryPhrase.error.unknown')}
-          </Text>
-          <Button onPress={() => navigation.goBack()}>
-            <XStack gap="$2" items="center" px="$4" py="$2">
-              <Text fontSize="$4" fontWeight="600">
-                {t('common.goBack')}
-              </Text>
-            </XStack>
-          </Button>
+          <YStack w="100%" maxWidth={contentMaxWidth} items="center" gap="$4">
+            <Text color="$error" text="center" fontSize="$5" fontWeight="700">
+              {t('onboarding.recoveryPhrase.error.title')}
+            </Text>
+            <Text color="$textSecondary" text="center" fontSize="$4">
+              {generateError instanceof Error
+                ? generateError.message
+                : t('onboarding.recoveryPhrase.error.unknown')}
+            </Text>
+            <Button onPress={() => navigation.goBack()}>
+              <XStack gap="$2" items="center" px="$4" py="$2">
+                <Text fontSize="$4" fontWeight="600">
+                  {t('common.goBack')}
+                </Text>
+              </XStack>
+            </Button>
+          </YStack>
         </YStack>
       </OnboardingBackground>
     );
@@ -210,142 +214,147 @@ export function RecoveryPhraseScreen(): React.ReactElement {
       {/* Only show content when not loading */}
       {!isLoading && (
         <OnboardingBackground>
-          <YStack flex={1} px="$4">
-            {/* Title and description */}
-            <YStack items="center" mb="$6" gap="$2">
-              <Text fontSize="$8" fontWeight="700" color="$text" text="center" lineHeight="$8">
-                {t('onboarding.recoveryPhrase.title')}
-              </Text>
-              <Text fontSize="$4" color="$textSecondary" text="center" lineHeight="$4" maxW={280}>
-                {t('onboarding.recoveryPhrase.description')}
-              </Text>
-            </YStack>
+          <YStack flex={1} px="$4" items="center">
+            {/* Responsive content container - constrained width on iPad */}
+            <YStack flex={1} w="100%" maxWidth={contentMaxWidth}>
+              {/* Title and description */}
+              <YStack items="center" mb="$6" gap="$2">
+                <Text fontSize="$8" fontWeight="700" color="$text" text="center" lineHeight="$8">
+                  {t('onboarding.recoveryPhrase.title')}
+                </Text>
+                <Text fontSize="$4" color="$textSecondary" text="center" lineHeight="$4" maxW={280}>
+                  {t('onboarding.recoveryPhrase.description')}
+                </Text>
+              </YStack>
 
-            {/* Recovery phrase grid - 2 columns x 6 rows */}
-            <YStack
-              width={320}
-              bg="$bgGlass"
-              rounded="$4"
-              pt="$6"
-              pb="$6"
-              px="$4.5"
-              mb="$4"
-              self="center"
-              position="relative"
-            >
-              {/* Only render words when phrase is revealed */}
-              {isPhraseRevealed ? (
-                <YStack gap="$5">
-                  {/* Generate 6 rows with 2 columns each */}
-                  {Array.from({ length: 6 }, (_, rowIndex) => (
-                    <XStack key={rowIndex} gap="$10" justify="space-between">
-                      {/* Left column */}
-                      {recoveryPhrase[rowIndex * 2] && (
-                        <XStack gap="$2" items="center" flex={1}>
-                          <YStack
-                            width="$8"
-                            height="$8"
-                            bg="$bgGlass"
-                            rounded="$2"
-                            items="center"
-                            justify="center"
-                            shrink={0}
-                          >
-                            <Text fontSize="$5" color="$text">
-                              {rowIndex * 2 + 1}
-                            </Text>
-                          </YStack>
-                          <Text fontSize="$4" color="$text">
-                            {recoveryPhrase[rowIndex * 2]}
-                          </Text>
-                        </XStack>
-                      )}
-
-                      {/* Right column */}
-                      {recoveryPhrase[rowIndex * 2 + 1] && (
-                        <XStack gap="$2" items="center" flex={1}>
-                          <YStack
-                            width="$8"
-                            height="$8"
-                            bg="$bgGlass"
-                            rounded="$2"
-                            items="center"
-                            justify="center"
-                            shrink={0}
-                          >
-                            <Text fontSize="$5" color="$text">
-                              {rowIndex * 2 + 2}
-                            </Text>
-                          </YStack>
-                          <Text fontSize="$4" color="$text">
-                            {recoveryPhrase[rowIndex * 2 + 1]}
-                          </Text>
-                        </XStack>
-                      )}
-                    </XStack>
-                  ))}
-                </YStack>
-              ) : (
-                /* Click to reveal overlay - shown when phrase is not revealed */
-                <YStack
-                  height={340}
-                  items="center"
-                  justify="center"
-                  cursor="pointer"
-                  onPress={handleRevealPhrase}
-                >
-                  <YStack items="center" gap="$3">
-                    <View
-                      width={42}
-                      height={40}
-                      bg="$bgGlass"
-                      rounded="$2"
-                      items="center"
-                      justify="center"
-                    >
-                      <RevealPhrase size={20} color={theme.iconGlass.val} />
-                    </View>
-                    <Text fontSize="$4" fontWeight="500" color="$text" text="center">
-                      {t('onboarding.recoveryPhrase.clickToReveal')}
-                    </Text>
-                  </YStack>
-                </YStack>
-              )}
-            </YStack>
-
-            {/* Copy button */}
-            <XStack justify="center" mb="$4">
-              <Button variant="ghost" onPress={handleCopy}>
-                <XStack gap="$3" items="center">
-                  <Copy size={24} color={theme.primary.val} />
-                  <Text fontSize="$4" fontWeight="700" style={{ color: theme.primary.val }}>
-                    {copiedToClipboard ? t('messages.copied') : t('onboarding.recoveryPhrase.copy')}
-                  </Text>
-                </XStack>
-              </Button>
-            </XStack>
-
-            {/* Warning card */}
-            <WarningCard
-              icon={<Warning size={24} color={theme.iconGlass.val} />}
-              title={t('onboarding.recoveryPhrase.warning.title')}
-              description={t('onboarding.recoveryPhrase.warning.description')}
-            />
-
-            {/* Spacer */}
-            <YStack flex={1} />
-
-            {/* Next button - disabled until phrase is revealed */}
-            <YStack pb="$6">
-              <Button
-                variant="inverse"
-                size="large"
-                fullWidth
-                disabled={!isPhraseRevealed}
-                onPress={handleNext}
+              {/* Recovery phrase grid - 2 columns x 6 rows */}
+              <YStack
+                width={320}
+                bg="$bgGlass"
+                rounded="$4"
+                pt="$6"
+                pb="$6"
+                px="$4.5"
+                mb="$4"
+                self="center"
+                position="relative"
               >
-                {t('onboarding.recoveryPhrase.next')}
-              </Button>
+                {/* Only render words when phrase is revealed */}
+                {isPhraseRevealed ? (
+                  <YStack gap="$5">
+                    {/* Generate 6 rows with 2 columns each */}
+                    {Array.from({ length: 6 }, (_, rowIndex) => (
+                      <XStack key={rowIndex} gap="$10" justify="space-between">
+                        {/* Left column */}
+                        {recoveryPhrase[rowIndex * 2] && (
+                          <XStack gap="$2" items="center" flex={1}>
+                            <YStack
+                              width="$8"
+                              height="$8"
+                              bg="$bgGlass"
+                              rounded="$2"
+                              items="center"
+                              justify="center"
+                              shrink={0}
+                            >
+                              <Text fontSize="$5" color="$text">
+                                {rowIndex * 2 + 1}
+                              </Text>
+                            </YStack>
+                            <Text fontSize="$4" color="$text">
+                              {recoveryPhrase[rowIndex * 2]}
+                            </Text>
+                          </XStack>
+                        )}
+
+                        {/* Right column */}
+                        {recoveryPhrase[rowIndex * 2 + 1] && (
+                          <XStack gap="$2" items="center" flex={1}>
+                            <YStack
+                              width="$8"
+                              height="$8"
+                              bg="$bgGlass"
+                              rounded="$2"
+                              items="center"
+                              justify="center"
+                              shrink={0}
+                            >
+                              <Text fontSize="$5" color="$text">
+                                {rowIndex * 2 + 2}
+                              </Text>
+                            </YStack>
+                            <Text fontSize="$4" color="$text">
+                              {recoveryPhrase[rowIndex * 2 + 1]}
+                            </Text>
+                          </XStack>
+                        )}
+                      </XStack>
+                    ))}
+                  </YStack>
+                ) : (
+                  /* Click to reveal overlay - shown when phrase is not revealed */
+                  <YStack
+                    height={340}
+                    items="center"
+                    justify="center"
+                    cursor="pointer"
+                    onPress={handleRevealPhrase}
+                  >
+                    <YStack items="center" gap="$3">
+                      <View
+                        width={42}
+                        height={40}
+                        bg="$bgGlass"
+                        rounded="$2"
+                        items="center"
+                        justify="center"
+                      >
+                        <RevealPhrase size={20} color={theme.iconGlass.val} />
+                      </View>
+                      <Text fontSize="$4" fontWeight="500" color="$text" text="center">
+                        {t('onboarding.recoveryPhrase.clickToReveal')}
+                      </Text>
+                    </YStack>
+                  </YStack>
+                )}
+              </YStack>
+
+              {/* Copy button */}
+              <XStack justify="center" mb="$4">
+                <Button variant="ghost" onPress={handleCopy}>
+                  <XStack gap="$3" items="center">
+                    <Copy size={24} color={theme.primary.val} />
+                    <Text fontSize="$4" fontWeight="700" style={{ color: theme.primary.val }}>
+                      {copiedToClipboard
+                        ? t('messages.copied')
+                        : t('onboarding.recoveryPhrase.copy')}
+                    </Text>
+                  </XStack>
+                </Button>
+              </XStack>
+
+              {/* Warning card */}
+              <WarningCard
+                icon={<Warning size={24} color={theme.iconGlass.val} />}
+                title={t('onboarding.recoveryPhrase.warning.title')}
+                description={t('onboarding.recoveryPhrase.warning.description')}
+              />
+
+              {/* Spacer */}
+              <YStack flex={1} />
+
+              {/* Next button - disabled until phrase is revealed */}
+              <YStack pb="$6">
+                <Button
+                  variant="inverse"
+                  size="large"
+                  fullWidth
+                  disabled={!isPhraseRevealed}
+                  onPress={handleNext}
+                >
+                  {t('onboarding.recoveryPhrase.next')}
+                </Button>
+              </YStack>
             </YStack>
           </YStack>
         </OnboardingBackground>

--- a/packages/screens/src/onboarding/SecureEnclaveScreen.query.tsx
+++ b/packages/screens/src/onboarding/SecureEnclaveScreen.query.tsx
@@ -14,6 +14,7 @@ import {
   AccountCreationLoadingState,
   ShieldAnimation,
   useTheme,
+  useResponsive,
 } from '@onflow/frw-ui';
 import { generateRandomUsername } from '@onflow/frw-utils';
 import React, { useState, useLayoutEffect, useEffect } from 'react';
@@ -34,6 +35,7 @@ export function SecureEnclaveScreen({
 }: SecureEnclaveScreenProps = {}): React.ReactElement {
   const { t } = useTranslation();
   const theme = useTheme();
+  const { contentMaxWidth, animationScale } = useResponsive();
   const [showConfirmDialog, setShowConfirmDialog] = useState(false);
   const [showLoadingState, setShowLoadingState] = useState(false);
   const [progress, setProgress] = useState<number | undefined>(undefined);
@@ -167,66 +169,74 @@ export function SecureEnclaveScreen({
   return (
     <>
       <OnboardingBackground>
-        <YStack flex={1} px="$4">
-          {/* Advanced text */}
-          <YStack mb="$6">
-            <Text fontSize={30} fontWeight="700" color="$text" textAlign="center" lineHeight={36}>
-              {t('onboarding.secureEnclave.title')}
-            </Text>
-          </YStack>
-
-          {/* Shield Animation */}
-          <YStack alignItems="center" mb="$8">
-            <ShieldAnimation width={300} height={375} autoPlay={true} loop={true} />
-          </YStack>
-
-          {/* Card with profile description */}
-          <YStack items="center" mb="$8">
-            <YStack w="100%" maxW={320} items="center" gap="$2">
-              <Text fontSize="$5" fontWeight="700" color="$text" text="center" mb="$2">
-                {t('onboarding.secureEnclave.cardTitle')}
-              </Text>
-              <Text fontSize="$4" color="$textSecondary" text="center" lineHeight={17} px="$2">
-                {t('onboarding.secureEnclave.cardDescription')}
+        <YStack flex={1} px="$4" items="center">
+          {/* Responsive content container - constrained width on iPad */}
+          <YStack flex={1} w="100%" maxWidth={contentMaxWidth}>
+            {/* Advanced text */}
+            <YStack mb="$6">
+              <Text fontSize={30} fontWeight="700" color="$text" text="center" lineHeight={36}>
+                {t('onboarding.secureEnclave.title')}
               </Text>
             </YStack>
-          </YStack>
 
-          {/* Feature items */}
-          <YStack gap="$2" items="center" mb="$6">
-            {/* Secure enclave */}
-            <XStack gap="$2" items="center">
-              <SecureEnclave size={16} color={theme.primary.val} />
-              <Text fontSize="$4" color="$primary">
-                {t('onboarding.secureEnclave.features.secureEnclave')}
-              </Text>
-            </XStack>
+            {/* Shield Animation - scaled for iPad */}
+            <YStack items="center" mb="$8">
+              <ShieldAnimation
+                width={Math.round(300 * animationScale)}
+                height={Math.round(375 * animationScale)}
+                autoPlay={true}
+                loop={true}
+              />
+            </YStack>
 
-            {/* Hardware security */}
-            <XStack gap="$2" items="center">
-              <HardwareGradeSecurity size={16} color={theme.primary.val} />
-              <Text fontSize="$4" color="$primary">
-                {t('onboarding.secureEnclave.features.hardwareSecurity')}
-              </Text>
-            </XStack>
+            {/* Card with profile description */}
+            <YStack items="center" mb="$8">
+              <YStack w="100%" maxW={320} items="center" gap="$2">
+                <Text fontSize="$5" fontWeight="700" color="$text" text="center" mb="$2">
+                  {t('onboarding.secureEnclave.cardTitle')}
+                </Text>
+                <Text fontSize="$4" color="$textSecondary" text="center" lineHeight={17} px="$2">
+                  {t('onboarding.secureEnclave.cardDescription')}
+                </Text>
+              </YStack>
+            </YStack>
 
-            {/* No EVM support */}
-            <XStack gap="$2" items="center">
-              <ShieldOff size={16} color={theme.error.val} />
-              <Text fontSize="$4" color="$error">
-                {t('onboarding.secureEnclave.features.noEvm')}
-              </Text>
-            </XStack>
-          </YStack>
+            {/* Feature items */}
+            <YStack gap="$2" items="center" mb="$6">
+              {/* Secure enclave */}
+              <XStack gap="$2" items="center">
+                <SecureEnclave size={16} color={theme.primary.val} />
+                <Text fontSize="$4" color="$primary">
+                  {t('onboarding.secureEnclave.features.secureEnclave')}
+                </Text>
+              </XStack>
 
-          {/* Spacer */}
-          <YStack flex={1} />
+              {/* Hardware security */}
+              <XStack gap="$2" items="center">
+                <HardwareGradeSecurity size={16} color={theme.primary.val} />
+                <Text fontSize="$4" color="$primary">
+                  {t('onboarding.secureEnclave.features.hardwareSecurity')}
+                </Text>
+              </XStack>
 
-          {/* Next button */}
-          <YStack pb="$6">
-            <Button variant="inverse" size="large" fullWidth onPress={handleNext}>
-              {t('onboarding.secureEnclave.next')}
-            </Button>
+              {/* No EVM support */}
+              <XStack gap="$2" items="center">
+                <ShieldOff size={16} color={theme.error.val} />
+                <Text fontSize="$4" color="$error">
+                  {t('onboarding.secureEnclave.features.noEvm')}
+                </Text>
+              </XStack>
+            </YStack>
+
+            {/* Spacer */}
+            <YStack flex={1} />
+
+            {/* Next button */}
+            <YStack pb="$6">
+              <Button variant="inverse" size="large" fullWidth onPress={handleNext}>
+                {t('onboarding.secureEnclave.next')}
+              </Button>
+            </YStack>
           </YStack>
         </YStack>
       </OnboardingBackground>

--- a/packages/ui/src/hooks/index.ts
+++ b/packages/ui/src/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from './use-responsive';

--- a/packages/ui/src/hooks/use-responsive.ts
+++ b/packages/ui/src/hooks/use-responsive.ts
@@ -1,0 +1,57 @@
+import { useWindowDimensions, Platform } from 'react-native';
+
+interface ResponsiveValues {
+  /** Whether the device is a tablet (iPad) */
+  isTablet: boolean;
+  /** Maximum content width for readable text on larger screens */
+  contentMaxWidth: number | undefined;
+  /** Scale factor for animations (1.0 on phone, larger on tablet) */
+  animationScale: number;
+  /** Current screen width */
+  screenWidth: number;
+  /** Current screen height */
+  screenHeight: number;
+}
+
+/**
+ * useResponsive - Hook for responsive layout values on iOS
+ *
+ * Provides device type detection and responsive sizing utilities for iPad support.
+ * On iPad, content is constrained to a readable width and animations are scaled up.
+ *
+ * @example
+ * ```tsx
+ * const { isTablet, contentMaxWidth, animationScale } = useResponsive();
+ *
+ * <YStack maxW={contentMaxWidth} alignSelf="center">
+ *   <ShieldAnimation
+ *     width={300 * animationScale}
+ *     height={375 * animationScale}
+ *   />
+ * </YStack>
+ * ```
+ */
+export function useResponsive(): ResponsiveValues {
+  const { width, height } = useWindowDimensions();
+
+  // iPad detection using Platform.isPad (most reliable) or width threshold
+  // Width >= 768 catches iPad in portrait mode and larger tablets
+  const isTablet =
+    Platform.OS === 'ios' &&
+    ((Platform as unknown as { isPad?: boolean }).isPad === true || width >= 768);
+
+  // Content max width: 500px on iPad for optimal readability
+  // undefined on phone means full width (respecting parent padding)
+  const contentMaxWidth = isTablet ? 500 : undefined;
+
+  // Animation scale: 1.3x on iPad for better visual presence on larger screens
+  const animationScale = isTablet ? 1.3 : 1.0;
+
+  return {
+    isTablet,
+    contentMaxWidth,
+    animationScale,
+    screenWidth: width,
+    screenHeight: height,
+  };
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -139,3 +139,6 @@ export * from './types';
 
 // Export assets
 export * from './assets/images';
+
+// Export hooks
+export * from './hooks';


### PR DESCRIPTION
- Add useResponsive hook for iPad detection and responsive sizing
- Constrain content width to 500px on iPad for better readability
- Scale animations 1.3x larger on iPad for better visual presence
- Update all 6 onboarding screens with responsive container pattern


Closes #1231

## 🔗 Related Issues


Linked automatically from the branch name. If incorrect, edit:

<!-- Examples: -->
<!-- Closes #123 -->
<!-- Fixes #456 -->
<!-- Resolves #789 -->

## Self-Checklist

- [ ] I read through my own diff
- [ ] I ran at least one manual check
- [ ] No mock / debug code left in production code

## 📝 Description

<!-- Describe your changes in detail -->

## 📸 Screenshots/Videos

<!-- Add screenshots or videos if applicable -->
