### PR TITLE
feat: multi-EOA BIP44 derivation support

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -37,6 +37,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Reset generated files
+        run: git checkout -- .
+
       - name: Build packages
         run: pnpm build:packages
 

--- a/packages/wallet/src/__tests__/wallet-eoa.test.ts
+++ b/packages/wallet/src/__tests__/wallet-eoa.test.ts
@@ -198,6 +198,187 @@ describe('Wallet EOA address derivation', () => {
     expect(refreshed.get(0)).toBe(first.get(0));
   });
 
+  // --- Multi-EOA private key and signing tests ---
+
+  it('derives different private keys for different indexes', async () => {
+    const testMnemonic =
+      'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
+
+    const storage = new MemoryStorage();
+    const key = await SeedPhraseKey.createAdvanced(
+      {
+        mnemonic: testMnemonic,
+        derivationPath: "m/44'/539'/0'/0/0",
+        passphrase: '',
+      },
+      storage
+    );
+
+    // Get private keys for different indexes
+    const pk0 = await key.ethPrivateKey(0);
+    const pk1 = await key.ethPrivateKey(1);
+    const pk2 = await key.ethPrivateKey(2);
+
+    // All private keys must be 32 bytes
+    expect(pk0.length).toBe(32);
+    expect(pk1.length).toBe(32);
+    expect(pk2.length).toBe(32);
+
+    // All private keys must be different
+    expect(Buffer.from(pk0).toString('hex')).not.toBe(Buffer.from(pk1).toString('hex'));
+    expect(Buffer.from(pk1).toString('hex')).not.toBe(Buffer.from(pk2).toString('hex'));
+    expect(Buffer.from(pk0).toString('hex')).not.toBe(Buffer.from(pk2).toString('hex'));
+  });
+
+  it('derives different public keys for different indexes', async () => {
+    const testMnemonic =
+      'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
+
+    const storage = new MemoryStorage();
+    const key = await SeedPhraseKey.createAdvanced(
+      {
+        mnemonic: testMnemonic,
+        derivationPath: "m/44'/539'/0'/0/0",
+        passphrase: '',
+      },
+      storage
+    );
+
+    const pubKey0 = await key.ethPublicKey(0);
+    const pubKey1 = await key.ethPublicKey(1);
+
+    // Uncompressed secp256k1 public keys are 65 bytes (0x04 prefix + 64 bytes)
+    expect(pubKey0.length).toBe(65);
+    expect(pubKey1.length).toBe(65);
+
+    // Must be different
+    expect(Buffer.from(pubKey0).toString('hex')).not.toBe(Buffer.from(pubKey1).toString('hex'));
+  });
+
+  it('produces different signatures for same message with different indexes', async () => {
+    const testMnemonic =
+      'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
+
+    const storage = new MemoryStorage();
+    const key = await SeedPhraseKey.createAdvanced(
+      {
+        mnemonic: testMnemonic,
+        derivationPath: "m/44'/539'/0'/0/0",
+        passphrase: '',
+      },
+      storage
+    );
+    const wallet = WalletFactory.createKeyWallet(
+      key,
+      new Set([NETWORKS.FLOW_EVM_MAINNET]),
+      storage
+    );
+
+    const message = '0x' + Buffer.from('Hello Flow').toString('hex');
+
+    // Sign the same message with index 0 and index 1
+    const sig0 = await wallet.ethSignPersonalMessage(message, 0);
+    const sig1 = await wallet.ethSignPersonalMessage(message, 1);
+
+    // Both signatures must exist
+    expect(sig0.signature).toBeDefined();
+    expect(sig1.signature).toBeDefined();
+
+    // Signatures must be different (different private keys)
+    expect(sig0.signature).not.toBe(sig1.signature);
+  });
+
+  it('signs transaction with correct EOA index', async () => {
+    const testMnemonic =
+      'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
+
+    const storage = new MemoryStorage();
+    const key = await SeedPhraseKey.createAdvanced(
+      {
+        mnemonic: testMnemonic,
+        derivationPath: "m/44'/539'/0'/0/0",
+        passphrase: '',
+      },
+      storage
+    );
+    const wallet = WalletFactory.createKeyWallet(
+      key,
+      new Set([NETWORKS.FLOW_EVM_MAINNET]),
+      storage
+    );
+
+    // Derive addresses to know which address each index maps to
+    const addressMap = await wallet.getEOAAccount([0, 1]);
+
+    // Sign a transaction with index 1
+    const tx = {
+      chainId: 747,
+      to: '0x0000000000000000000000000000000000000001' as const,
+      value: '0x0',
+      nonce: 0,
+      gasLimit: '0x5208',
+      maxFeePerGas: '0x3B9ACA00',
+      maxPriorityFeePerGas: '0x3B9ACA00',
+    };
+
+    const signed0 = await wallet.ethSignTransaction(tx, 0);
+    const signed1 = await wallet.ethSignTransaction(tx, 1);
+
+    // Both must succeed
+    expect(signed0.rawTransaction).toBeDefined();
+    expect(signed1.rawTransaction).toBeDefined();
+
+    // Signed transactions must be different (different signing keys)
+    expect(signed0.rawTransaction).not.toBe(signed1.rawTransaction);
+  });
+
+  it('signs EIP-712 typed data with different indexes', async () => {
+    const testMnemonic =
+      'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
+
+    const storage = new MemoryStorage();
+    const key = await SeedPhraseKey.createAdvanced(
+      {
+        mnemonic: testMnemonic,
+        derivationPath: "m/44'/539'/0'/0/0",
+        passphrase: '',
+      },
+      storage
+    );
+    const wallet = WalletFactory.createKeyWallet(
+      key,
+      new Set([NETWORKS.FLOW_EVM_MAINNET]),
+      storage
+    );
+
+    const typedData = {
+      types: {
+        EIP712Domain: [
+          { name: 'name', type: 'string' },
+          { name: 'version', type: 'string' },
+          { name: 'chainId', type: 'uint256' },
+        ],
+        Message: [{ name: 'content', type: 'string' }],
+      },
+      primaryType: 'Message',
+      domain: {
+        name: 'Test',
+        version: '1',
+        chainId: 747,
+      },
+      message: {
+        content: 'Hello from typed data',
+      },
+    };
+
+    const sig0 = await wallet.ethSignTypedData(typedData, 0);
+    const sig1 = await wallet.ethSignTypedData(typedData, 1);
+
+    expect(sig0.signature).toBeDefined();
+    expect(sig1.signature).toBeDefined();
+    expect(sig0.signature).not.toBe(sig1.signature);
+  });
+
   // --- Usage examples as tests ---
 
   it('example: derive 5 EOA accounts and sign with index 2', async () => {

--- a/packages/wallet/src/__tests__/wallet-eoa.test.ts
+++ b/packages/wallet/src/__tests__/wallet-eoa.test.ts
@@ -2,11 +2,14 @@ import { describe, expect, it } from 'vitest';
 
 import { WalletCoreProvider } from '../crypto/wallet-core-provider';
 import { PrivateKey } from '../keys/private-key';
+import { SeedPhraseKey } from '../keys/seed-phrase-key';
 import { MemoryStorage } from '../storage/memory-storage';
 import { NETWORKS } from '../types/key';
 import { WalletFactory } from '../wallet';
 
 describe('Wallet EOA address derivation', () => {
+  // --- PrivateKey wallet (single EOA only) ---
+
   it('derives and caches the EOA address for a private key wallet', async () => {
     const samplePrivateKeyHex = '9a983cb3d832fbde5ab49d692b7a8bf5b5d232479c99333d0fc8e1d21f1b55b6';
     const expectedPrivateKeyEthAddress = '0x6Fac4D18c912343BF86fa7049364Dd4E424Ab9C0';
@@ -20,10 +23,255 @@ describe('Wallet EOA address derivation', () => {
       storage
     );
 
-    const addresses = await wallet.getEOAAccount();
+    const addressMap = await wallet.getEOAAccount();
 
-    expect(addresses.length).toBe(1);
-    expect(addresses[0]).toBe(expectedPrivateKeyEthAddress);
+    expect(addressMap.size).toBe(1);
+    expect(addressMap.get(0)).toBe(expectedPrivateKeyEthAddress);
     expect(wallet.eoaAddress).toEqual(new Set([expectedPrivateKeyEthAddress]));
+    expect(wallet.eoaAddressMap).toEqual(new Map([[0, expectedPrivateKeyEthAddress]]));
+  });
+
+  it('throws for PrivateKey with index > 0', async () => {
+    const samplePrivateKeyHex = '9a983cb3d832fbde5ab49d692b7a8bf5b5d232479c99333d0fc8e1d21f1b55b6';
+
+    const storage = new MemoryStorage();
+    const privateKeyBytes = await WalletCoreProvider.hexToBytes(samplePrivateKeyHex);
+    const key = new PrivateKey(storage, privateKeyBytes);
+    const wallet = WalletFactory.createKeyWallet(
+      key,
+      new Set([NETWORKS.FLOW_EVM_MAINNET]),
+      storage
+    );
+
+    await expect(wallet.getEOAAccount([0, 1])).rejects.toThrow();
+  });
+
+  // --- SeedPhrase wallet (multi-EOA) ---
+
+  it('defaults to index [0] when no indexes provided', async () => {
+    const testMnemonic =
+      'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
+
+    const storage = new MemoryStorage();
+    const key = await SeedPhraseKey.createAdvanced(
+      {
+        mnemonic: testMnemonic,
+        derivationPath: "m/44'/539'/0'/0/0",
+        passphrase: '',
+      },
+      storage
+    );
+    const wallet = WalletFactory.createKeyWallet(
+      key,
+      new Set([NETWORKS.FLOW_EVM_MAINNET]),
+      storage
+    );
+
+    const addressMap = await wallet.getEOAAccount();
+
+    expect(addressMap.size).toBe(1);
+    expect(addressMap.has(0)).toBe(true);
+    expect(addressMap.get(0)).toMatch(/^0x[0-9a-fA-F]{40}$/);
+  });
+
+  it('derives multiple EOA addresses from a seed phrase', async () => {
+    const testMnemonic =
+      'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
+
+    const storage = new MemoryStorage();
+    const key = await SeedPhraseKey.createAdvanced(
+      {
+        mnemonic: testMnemonic,
+        derivationPath: "m/44'/539'/0'/0/0",
+        passphrase: '',
+      },
+      storage
+    );
+    const wallet = WalletFactory.createKeyWallet(
+      key,
+      new Set([NETWORKS.FLOW_EVM_MAINNET]),
+      storage
+    );
+
+    // Derive index 0, 1, and 2
+    const addressMap = await wallet.getEOAAccount([0, 1, 2]);
+
+    expect(addressMap.size).toBe(3);
+    expect(addressMap.has(0)).toBe(true);
+    expect(addressMap.has(1)).toBe(true);
+    expect(addressMap.has(2)).toBe(true);
+
+    // All addresses must be different
+    const addresses = [...addressMap.values()];
+    const uniqueAddresses = new Set(addresses);
+    expect(uniqueAddresses.size).toBe(3);
+
+    // All should be valid checksummed Ethereum addresses
+    for (const addr of addresses) {
+      expect(addr).toMatch(/^0x[0-9a-fA-F]{40}$/);
+    }
+
+    // eoaAddress set contains all three
+    expect(wallet.eoaAddress.size).toBe(3);
+  });
+
+  it('returns cached addresses without re-derivation when forceRefresh is false', async () => {
+    const testMnemonic =
+      'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
+
+    const storage = new MemoryStorage();
+    const key = await SeedPhraseKey.createAdvanced(
+      {
+        mnemonic: testMnemonic,
+        derivationPath: "m/44'/539'/0'/0/0",
+        passphrase: '',
+      },
+      storage
+    );
+    const wallet = WalletFactory.createKeyWallet(
+      key,
+      new Set([NETWORKS.FLOW_EVM_MAINNET]),
+      storage
+    );
+
+    // First call derives
+    const first = await wallet.getEOAAccount([0, 1]);
+    // Second call should return same results from cache
+    const second = await wallet.getEOAAccount([0, 1]);
+
+    expect(second).toEqual(first);
+  });
+
+  it('merges new indexes into existing cache', async () => {
+    const testMnemonic =
+      'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
+
+    const storage = new MemoryStorage();
+    const key = await SeedPhraseKey.createAdvanced(
+      {
+        mnemonic: testMnemonic,
+        derivationPath: "m/44'/539'/0'/0/0",
+        passphrase: '',
+      },
+      storage
+    );
+    const wallet = WalletFactory.createKeyWallet(
+      key,
+      new Set([NETWORKS.FLOW_EVM_MAINNET]),
+      storage
+    );
+
+    // Derive index 0
+    await wallet.getEOAAccount([0]);
+    expect(wallet.eoaAddressMap.size).toBe(1);
+
+    // Derive index 1 — should merge, not replace
+    await wallet.getEOAAccount([1]);
+    expect(wallet.eoaAddressMap.size).toBe(2);
+    expect(wallet.eoaAddressMap.has(0)).toBe(true);
+    expect(wallet.eoaAddressMap.has(1)).toBe(true);
+  });
+
+  it('forceRefresh re-derives even when cached', async () => {
+    const testMnemonic =
+      'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
+
+    const storage = new MemoryStorage();
+    const key = await SeedPhraseKey.createAdvanced(
+      {
+        mnemonic: testMnemonic,
+        derivationPath: "m/44'/539'/0'/0/0",
+        passphrase: '',
+      },
+      storage
+    );
+    const wallet = WalletFactory.createKeyWallet(
+      key,
+      new Set([NETWORKS.FLOW_EVM_MAINNET]),
+      storage
+    );
+
+    const first = await wallet.getEOAAccount([0]);
+    const refreshed = await wallet.getEOAAccount([0], true);
+
+    // Same addresses, just re-derived
+    expect(refreshed.get(0)).toBe(first.get(0));
+  });
+
+  // --- Usage examples as tests ---
+
+  it('example: derive 5 EOA accounts and sign with index 2', async () => {
+    const testMnemonic =
+      'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
+
+    const storage = new MemoryStorage();
+    const key = await SeedPhraseKey.createAdvanced(
+      {
+        mnemonic: testMnemonic,
+        derivationPath: "m/44'/539'/0'/0/0",
+        passphrase: '',
+      },
+      storage
+    );
+    const wallet = WalletFactory.createKeyWallet(
+      key,
+      new Set([NETWORKS.FLOW_EVM_MAINNET]),
+      storage
+    );
+
+    // Step 1: Derive 5 EOA addresses
+    const addressMap = await wallet.getEOAAccount([0, 1, 2, 3, 4]);
+    expect(addressMap.size).toBe(5);
+
+    // Step 2: Sign a personal message with index 2
+    const message = '0x' + Buffer.from('Hello from EOA #2').toString('hex');
+    const signed = await wallet.ethSignPersonalMessage(message, 2);
+    expect(signed).toBeDefined();
+    expect(signed.signature).toBeDefined();
+
+    // Step 3: Later, add index 5 without losing 0-4
+    const newAddress = await wallet.getEOAAccount([5]);
+    expect(newAddress.size).toBe(1);
+    expect(wallet.eoaAddressMap.size).toBe(6); // 0-5 all cached
+  });
+
+  it('example: lookup index by address for signing', async () => {
+    const testMnemonic =
+      'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
+
+    const storage = new MemoryStorage();
+    const key = await SeedPhraseKey.createAdvanced(
+      {
+        mnemonic: testMnemonic,
+        derivationPath: "m/44'/539'/0'/0/0",
+        passphrase: '',
+      },
+      storage
+    );
+    const wallet = WalletFactory.createKeyWallet(
+      key,
+      new Set([NETWORKS.FLOW_EVM_MAINNET]),
+      storage
+    );
+
+    // Derive multiple EOAs
+    const addressMap = await wallet.getEOAAccount([0, 1, 2]);
+
+    // Find which index owns a specific address
+    const targetAddress = addressMap.get(1)!;
+    let signingIndex: number | undefined;
+    for (const [index, addr] of wallet.eoaAddressMap) {
+      if (addr === targetAddress) {
+        signingIndex = index;
+        break;
+      }
+    }
+
+    expect(signingIndex).toBe(1);
+
+    // Sign with the found index
+    const message = '0x' + Buffer.from('Sign with correct key').toString('hex');
+    const signed = await wallet.ethSignPersonalMessage(message, signingIndex!);
+    expect(signed.signature).toBeDefined();
   });
 });

--- a/packages/wallet/src/__tests__/wallet-eoa.test.ts
+++ b/packages/wallet/src/__tests__/wallet-eoa.test.ts
@@ -240,25 +240,7 @@ describe("Wallet multi-EOA (BIP44 m/44'/60'/0'/0/{index})", () => {
     expect(Buffer.from(pubKey0).toString('hex')).not.toBe(Buffer.from(pubKey1).toString('hex'));
   });
 
-  // --- Usage example (matches iOS pattern) ---
-
-  it('example: derive EOAs and sign directly on each account', async () => {
-    const { wallet } = await createTestSeedPhraseWallet();
-
-    // Derive 3 EOA accounts
-    const accounts = await wallet.getEOAAccount([0, 1, 2]);
-
-    for (const account of accounts) {
-      // Each account knows its own index and address
-      expect(account.index).toBeGreaterThanOrEqual(0);
-      expect(account.address).toMatch(/^0x[0-9a-fA-F]{40}$/);
-
-      // Sign directly — no need to pass index
-      const message = '0x' + Buffer.from(`hello from EOA #${account.index}`).toString('hex');
-      const sig = await account.signPersonalMessage(message);
-      expect(sig.signature).toBeDefined();
-    }
-  });
+  // --- Cache persistence ---
 
   it('persists EOA addresses in cache and restores on initialize', async () => {
     const storage = new MemoryStorage();
@@ -271,7 +253,6 @@ describe("Wallet multi-EOA (BIP44 m/44'/60'/0'/0/{index})", () => {
       storage
     );
 
-    // Use a shared cacheStorage so a second wallet instance can read it
     const cacheStorage = new MemoryStorage();
     const wallet1 = WalletFactory.createKeyWallet(
       key,
@@ -279,44 +260,175 @@ describe("Wallet multi-EOA (BIP44 m/44'/60'/0'/0/{index})", () => {
       cacheStorage
     );
 
-    // Derive EOAs and trigger cache write via fetchAccount
     const accounts = await wallet1.getEOAAccount([0, 1, 2]);
     expect(accounts.length).toBe(3);
 
-    // Manually trigger cache write (fetchAccount calls this internally)
-    // We call initialize which will call fetchAccount which caches
+    // fetchAccount triggers cacheAccountData() which persists _eoaAddressMap
     await wallet1.fetchAccount();
 
-    // Create a second wallet instance with the same cacheStorage
+    // New wallet instance sharing the same cache
     const wallet2 = WalletFactory.createKeyWallet(
       key,
       new Set([NETWORKS.FLOW_EVM_MAINNET]),
       cacheStorage
     );
-
-    // Initialize loads from cache
     await wallet2.initialize();
 
-    // EOA addresses should be restored from cache
     expect(wallet2.eoaAddressMap.size).toBeGreaterThanOrEqual(1);
-    // The index 0 address (from discoverEVMAccounts in fetchAccount) should be cached
     expect(wallet2.eoaAddressMap.get(0)).toBe(accounts[0].address);
   });
 
-  it('example: add more EOAs later and sign', async () => {
+  // ============================================================
+  // Standard Usage Examples
+  // These tests demonstrate the recommended API patterns.
+  // ============================================================
+
+  it('usage: create wallet and derive default EOA (index 0)', async () => {
+    // 1. Create a SeedPhraseKey from mnemonic
+    const storage = new MemoryStorage();
+    const key = await SeedPhraseKey.createAdvanced(
+      { mnemonic: TEST_MNEMONIC, derivationPath: BIP44_PATHS.EVM, passphrase: '' },
+      storage
+    );
+
+    // 2. Create a wallet
+    const wallet = WalletFactory.createKeyWallet(
+      key,
+      new Set([NETWORKS.FLOW_EVM_MAINNET]),
+      storage
+    );
+
+    // 3. Get default EOA (index 0)
+    const [defaultEOA] = await wallet.getEOAAccount();
+
+    expect(defaultEOA.index).toBe(0);
+    expect(defaultEOA.address).toMatch(/^0x[0-9a-fA-F]{40}$/);
+  });
+
+  it('usage: derive multiple EOAs and iterate', async () => {
     const { wallet } = await createTestSeedPhraseWallet();
 
-    // Start with 2 accounts
-    const initial = await wallet.getEOAAccount([0, 1]);
-    expect(initial.length).toBe(2);
+    // Derive 3 EOA accounts (m/44'/60'/0'/0/0, /1, /2)
+    const accounts = await wallet.getEOAAccount([0, 1, 2]);
 
-    // Add index 5 later — cache merges
-    const [eoa5] = await wallet.getEOAAccount([5]);
-    expect(wallet.eoaAddressMap.size).toBe(3); // 0, 1, 5
+    for (const account of accounts) {
+      expect(account.index).toBeGreaterThanOrEqual(0);
+      expect(account.address).toMatch(/^0x[0-9a-fA-F]{40}$/);
+    }
 
-    // Sign directly on the new account
-    const message = '0x' + Buffer.from('hello from EOA #5').toString('hex');
-    const sig = await eoa5.signPersonalMessage(message);
+    // All addresses are unique
+    const addresses = accounts.map((a) => a.address);
+    expect(new Set(addresses).size).toBe(3);
+  });
+
+  it('usage: sign personal message (EIP-191) with a specific EOA', async () => {
+    const { wallet } = await createTestSeedPhraseWallet();
+
+    const [, eoa1] = await wallet.getEOAAccount([0, 1]);
+
+    // Sign directly on the account object
+    const message = '0x' + Buffer.from('Hello from EOA #1').toString('hex');
+    const signed = await eoa1.signPersonalMessage(message);
+
+    expect(signed.signature).toBeDefined();
+    expect(signed.signature).toMatch(/^0x[0-9a-fA-F]+$/);
+  });
+
+  it('usage: sign EIP-1559 transaction with a specific EOA', async () => {
+    const { wallet } = await createTestSeedPhraseWallet();
+
+    const [eoa0] = await wallet.getEOAAccount([0]);
+
+    const tx = {
+      chainId: 747, // Flow EVM
+      to: '0x0000000000000000000000000000000000000001' as const,
+      value: '0x0',
+      nonce: 0,
+      gasLimit: '0x5208',
+      maxFeePerGas: '0x3B9ACA00',
+      maxPriorityFeePerGas: '0x3B9ACA00',
+    };
+
+    const signed = await eoa0.signTransaction(tx);
+
+    expect(signed.rawTransaction).toBeDefined();
+    expect(signed.transactionHash).toBeDefined();
+  });
+
+  it('usage: sign EIP-712 typed data with a specific EOA', async () => {
+    const { wallet } = await createTestSeedPhraseWallet();
+
+    const [eoa0] = await wallet.getEOAAccount([0]);
+
+    const typedData = {
+      types: {
+        EIP712Domain: [
+          { name: 'name', type: 'string' },
+          { name: 'chainId', type: 'uint256' },
+        ],
+        Transfer: [
+          { name: 'to', type: 'address' },
+          { name: 'amount', type: 'uint256' },
+        ],
+      },
+      primaryType: 'Transfer',
+      domain: { name: 'FlowWallet', chainId: 747 },
+      message: { to: '0x0000000000000000000000000000000000000001', amount: '1000000' },
+    };
+
+    const signed = await eoa0.signTypedData(typedData);
+
+    expect(signed.signature).toBeDefined();
+  });
+
+  it('usage: get private key and public key for an EOA', async () => {
+    const { wallet } = await createTestSeedPhraseWallet();
+
+    const [eoa0] = await wallet.getEOAAccount([0]);
+
+    // Get raw 32-byte secp256k1 private key
+    const privateKey = await eoa0.getPrivateKey();
+    expect(privateKey.length).toBe(32);
+
+    // Get uncompressed 65-byte secp256k1 public key (0x04 prefix)
+    const publicKey = await eoa0.getPublicKey();
+    expect(publicKey.length).toBe(65);
+    expect(publicKey[0]).toBe(0x04);
+  });
+
+  it('usage: add EOAs incrementally (cache merges)', async () => {
+    const { wallet } = await createTestSeedPhraseWallet();
+
+    // Start with EOA #0
+    await wallet.getEOAAccount([0]);
+    expect(wallet.eoaAddressMap.size).toBe(1);
+
+    // Later add EOA #1 and #2 — existing #0 stays cached
+    await wallet.getEOAAccount([1, 2]);
+    expect(wallet.eoaAddressMap.size).toBe(3);
+
+    // Can also jump to any index
+    const [eoa10] = await wallet.getEOAAccount([10]);
+    expect(wallet.eoaAddressMap.size).toBe(4);
+    expect(eoa10.index).toBe(10);
+  });
+
+  it('usage: find EOA by address and sign', async () => {
+    const { wallet } = await createTestSeedPhraseWallet();
+
+    const accounts = await wallet.getEOAAccount([0, 1, 2]);
+
+    // Simulate: user selected an address in the UI
+    const selectedAddress = accounts[2].address;
+
+    // Find the matching EOAAccount
+    const matchedAccount = accounts.find((a) => a.address === selectedAddress);
+    expect(matchedAccount).toBeDefined();
+    expect(matchedAccount!.index).toBe(2);
+
+    // Sign with it
+    const message = '0x' + Buffer.from('confirm action').toString('hex');
+    const sig = await matchedAccount!.signPersonalMessage(message);
     expect(sig.signature).toBeDefined();
   });
 });

--- a/packages/wallet/src/__tests__/wallet-eoa.test.ts
+++ b/packages/wallet/src/__tests__/wallet-eoa.test.ts
@@ -260,6 +260,49 @@ describe("Wallet multi-EOA (BIP44 m/44'/60'/0'/0/{index})", () => {
     }
   });
 
+  it('persists EOA addresses in cache and restores on initialize', async () => {
+    const storage = new MemoryStorage();
+    const key = await SeedPhraseKey.createAdvanced(
+      {
+        mnemonic: TEST_MNEMONIC,
+        derivationPath: BIP44_PATHS.EVM,
+        passphrase: '',
+      },
+      storage
+    );
+
+    // Use a shared cacheStorage so a second wallet instance can read it
+    const cacheStorage = new MemoryStorage();
+    const wallet1 = WalletFactory.createKeyWallet(
+      key,
+      new Set([NETWORKS.FLOW_EVM_MAINNET]),
+      cacheStorage
+    );
+
+    // Derive EOAs and trigger cache write via fetchAccount
+    const accounts = await wallet1.getEOAAccount([0, 1, 2]);
+    expect(accounts.length).toBe(3);
+
+    // Manually trigger cache write (fetchAccount calls this internally)
+    // We call initialize which will call fetchAccount which caches
+    await wallet1.fetchAccount();
+
+    // Create a second wallet instance with the same cacheStorage
+    const wallet2 = WalletFactory.createKeyWallet(
+      key,
+      new Set([NETWORKS.FLOW_EVM_MAINNET]),
+      cacheStorage
+    );
+
+    // Initialize loads from cache
+    await wallet2.initialize();
+
+    // EOA addresses should be restored from cache
+    expect(wallet2.eoaAddressMap.size).toBeGreaterThanOrEqual(1);
+    // The index 0 address (from discoverEVMAccounts in fetchAccount) should be cached
+    expect(wallet2.eoaAddressMap.get(0)).toBe(accounts[0].address);
+  });
+
   it('example: add more EOAs later and sign', async () => {
     const { wallet } = await createTestSeedPhraseWallet();
 

--- a/packages/wallet/src/__tests__/wallet-eoa.test.ts
+++ b/packages/wallet/src/__tests__/wallet-eoa.test.ts
@@ -48,10 +48,11 @@ describe("Wallet multi-EOA (BIP44 m/44'/60'/0'/0/{index})", () => {
       storage
     );
 
-    const addressMap = await wallet.getEOAAccount();
+    const accounts = await wallet.getEOAAccount();
 
-    expect(addressMap.size).toBe(1);
-    expect(addressMap.get(0)).toBe(expectedPrivateKeyEthAddress);
+    expect(accounts.length).toBe(1);
+    expect(accounts[0].index).toBe(0);
+    expect(accounts[0].address).toBe(expectedPrivateKeyEthAddress);
     expect(wallet.eoaAddress).toEqual(new Set([expectedPrivateKeyEthAddress]));
     expect(wallet.eoaAddressMap).toEqual(new Map([[0, expectedPrivateKeyEthAddress]]));
   });
@@ -76,23 +77,26 @@ describe("Wallet multi-EOA (BIP44 m/44'/60'/0'/0/{index})", () => {
   it('defaults to index [0] when no indexes provided', async () => {
     const { wallet } = await createTestSeedPhraseWallet();
 
-    const addressMap = await wallet.getEOAAccount();
+    const accounts = await wallet.getEOAAccount();
 
-    expect(addressMap.size).toBe(1);
-    expect(addressMap.has(0)).toBe(true);
-    expect(addressMap.get(0)).toMatch(/^0x[0-9a-fA-F]{40}$/);
+    expect(accounts.length).toBe(1);
+    expect(accounts[0].index).toBe(0);
+    expect(accounts[0].address).toMatch(/^0x[0-9a-fA-F]{40}$/);
   });
 
-  it('derives multiple EOA addresses from a seed phrase', async () => {
+  it('derives multiple EOA accounts from a seed phrase', async () => {
     const { wallet } = await createTestSeedPhraseWallet();
 
     // Derive via ETH BIP44: m/44'/60'/0'/0/0, m/44'/60'/0'/0/1, m/44'/60'/0'/0/2
-    const addressMap = await wallet.getEOAAccount([0, 1, 2]);
+    const accounts = await wallet.getEOAAccount([0, 1, 2]);
 
-    expect(addressMap.size).toBe(3);
+    expect(accounts.length).toBe(3);
+    expect(accounts[0].index).toBe(0);
+    expect(accounts[1].index).toBe(1);
+    expect(accounts[2].index).toBe(2);
 
-    // All addresses must be different (different BIP44 indexes → different keys)
-    const addresses = [...addressMap.values()];
+    // All addresses must be different (different BIP44 indexes -> different keys)
+    const addresses = accounts.map((a) => a.address);
     expect(new Set(addresses).size).toBe(3);
 
     // All should be valid checksummed Ethereum addresses
@@ -103,13 +107,13 @@ describe("Wallet multi-EOA (BIP44 m/44'/60'/0'/0/{index})", () => {
     expect(wallet.eoaAddress.size).toBe(3);
   });
 
-  it('returns cached addresses without re-derivation when forceRefresh is false', async () => {
+  it('returns cached accounts without re-derivation when forceRefresh is false', async () => {
     const { wallet } = await createTestSeedPhraseWallet();
 
     const first = await wallet.getEOAAccount([0, 1]);
     const second = await wallet.getEOAAccount([0, 1]);
 
-    expect(second).toEqual(first);
+    expect(second.map((a) => a.address)).toEqual(first.map((a) => a.address));
   });
 
   it('merges new indexes into existing cache', async () => {
@@ -118,7 +122,6 @@ describe("Wallet multi-EOA (BIP44 m/44'/60'/0'/0/{index})", () => {
     await wallet.getEOAAccount([0]);
     expect(wallet.eoaAddressMap.size).toBe(1);
 
-    // Derive index 1 — should merge, not replace
     await wallet.getEOAAccount([1]);
     expect(wallet.eoaAddressMap.size).toBe(2);
     expect(wallet.eoaAddressMap.has(0)).toBe(true);
@@ -131,67 +134,31 @@ describe("Wallet multi-EOA (BIP44 m/44'/60'/0'/0/{index})", () => {
     const first = await wallet.getEOAAccount([0]);
     const refreshed = await wallet.getEOAAccount([0], true);
 
-    expect(refreshed.get(0)).toBe(first.get(0));
+    expect(refreshed[0].address).toBe(first[0].address);
   });
 
-  // --- SeedPhrase wallet: per-index key derivation (m/44'/60'/0'/0/{index}) ---
+  // --- EOAAccount: direct signing via account object ---
 
-  it('derives different private keys for different ETH BIP44 indexes', async () => {
-    const { key } = await createTestSeedPhraseWallet();
-
-    // ethPrivateKey uses m/44'/60'/0'/0/{index} internally
-    const pk0 = await key.ethPrivateKey(0);
-    const pk1 = await key.ethPrivateKey(1);
-    const pk2 = await key.ethPrivateKey(2);
-
-    // All private keys must be 32 bytes (secp256k1)
-    expect(pk0.length).toBe(32);
-    expect(pk1.length).toBe(32);
-    expect(pk2.length).toBe(32);
-
-    // All private keys must be different
-    const hex0 = Buffer.from(pk0).toString('hex');
-    const hex1 = Buffer.from(pk1).toString('hex');
-    const hex2 = Buffer.from(pk2).toString('hex');
-    expect(hex0).not.toBe(hex1);
-    expect(hex1).not.toBe(hex2);
-    expect(hex0).not.toBe(hex2);
-  });
-
-  it('derives different public keys for different ETH BIP44 indexes', async () => {
-    const { key } = await createTestSeedPhraseWallet();
-
-    const pubKey0 = await key.ethPublicKey(0);
-    const pubKey1 = await key.ethPublicKey(1);
-
-    // Uncompressed secp256k1 public keys: 65 bytes (0x04 prefix + 64 bytes)
-    expect(pubKey0.length).toBe(65);
-    expect(pubKey1.length).toBe(65);
-
-    expect(Buffer.from(pubKey0).toString('hex')).not.toBe(Buffer.from(pubKey1).toString('hex'));
-  });
-
-  // --- SeedPhrase wallet: per-index signing ---
-
-  it('produces different signatures for same message with different indexes', async () => {
+  it('EOAAccount.signPersonalMessage signs with its own key', async () => {
     const { wallet } = await createTestSeedPhraseWallet();
 
+    const accounts = await wallet.getEOAAccount([0, 1]);
     const message = '0x' + Buffer.from('Hello Flow').toString('hex');
 
-    // Sign the same message with index 0 (m/44'/60'/0'/0/0) and index 1 (m/44'/60'/0'/0/1)
-    const sig0 = await wallet.ethSignPersonalMessage(message, 0);
-    const sig1 = await wallet.ethSignPersonalMessage(message, 1);
+    // Sign directly on the account object — no index needed
+    const sig0 = await accounts[0].signPersonalMessage(message);
+    const sig1 = await accounts[1].signPersonalMessage(message);
 
     expect(sig0.signature).toBeDefined();
     expect(sig1.signature).toBeDefined();
-    // Different private keys → different signatures
+    // Different accounts -> different private keys -> different signatures
     expect(sig0.signature).not.toBe(sig1.signature);
   });
 
-  it('signs transaction with correct EOA index', async () => {
+  it('EOAAccount.signTransaction signs with its own key', async () => {
     const { wallet } = await createTestSeedPhraseWallet();
 
-    await wallet.getEOAAccount([0, 1]);
+    const accounts = await wallet.getEOAAccount([0, 1]);
 
     const tx = {
       chainId: 747,
@@ -203,17 +170,18 @@ describe("Wallet multi-EOA (BIP44 m/44'/60'/0'/0/{index})", () => {
       maxPriorityFeePerGas: '0x3B9ACA00',
     };
 
-    const signed0 = await wallet.ethSignTransaction(tx, 0);
-    const signed1 = await wallet.ethSignTransaction(tx, 1);
+    const signed0 = await accounts[0].signTransaction(tx);
+    const signed1 = await accounts[1].signTransaction(tx);
 
     expect(signed0.rawTransaction).toBeDefined();
     expect(signed1.rawTransaction).toBeDefined();
-    // Different signing keys → different raw transactions
     expect(signed0.rawTransaction).not.toBe(signed1.rawTransaction);
   });
 
-  it('signs EIP-712 typed data with different indexes', async () => {
+  it('EOAAccount.signTypedData signs with its own key', async () => {
     const { wallet } = await createTestSeedPhraseWallet();
+
+    const accounts = await wallet.getEOAAccount([0, 1]);
 
     const typedData = {
       types: {
@@ -225,65 +193,87 @@ describe("Wallet multi-EOA (BIP44 m/44'/60'/0'/0/{index})", () => {
         Message: [{ name: 'content', type: 'string' }],
       },
       primaryType: 'Message',
-      domain: {
-        name: 'Test',
-        version: '1',
-        chainId: 747,
-      },
-      message: {
-        content: 'Hello from typed data',
-      },
+      domain: { name: 'Test', version: '1', chainId: 747 },
+      message: { content: 'Hello from typed data' },
     };
 
-    const sig0 = await wallet.ethSignTypedData(typedData, 0);
-    const sig1 = await wallet.ethSignTypedData(typedData, 1);
+    const sig0 = await accounts[0].signTypedData(typedData);
+    const sig1 = await accounts[1].signTypedData(typedData);
 
     expect(sig0.signature).toBeDefined();
     expect(sig1.signature).toBeDefined();
     expect(sig0.signature).not.toBe(sig1.signature);
   });
 
-  // --- Usage examples ---
-
-  it('example: derive 5 EOA accounts and sign with index 2', async () => {
+  it('EOAAccount.getPrivateKey returns different keys per index', async () => {
     const { wallet } = await createTestSeedPhraseWallet();
 
-    // Derive 5 EOA addresses (m/44'/60'/0'/0/0 through m/44'/60'/0'/0/4)
-    const addressMap = await wallet.getEOAAccount([0, 1, 2, 3, 4]);
-    expect(addressMap.size).toBe(5);
+    const accounts = await wallet.getEOAAccount([0, 1, 2]);
 
-    // Sign a personal message with index 2 (uses key from m/44'/60'/0'/0/2)
-    const message = '0x' + Buffer.from('Hello from EOA #2').toString('hex');
-    const signed = await wallet.ethSignPersonalMessage(message, 2);
-    expect(signed).toBeDefined();
-    expect(signed.signature).toBeDefined();
+    const pk0 = await accounts[0].getPrivateKey();
+    const pk1 = await accounts[1].getPrivateKey();
+    const pk2 = await accounts[2].getPrivateKey();
 
-    // Add index 5 later — merges into cache
-    const newAddress = await wallet.getEOAAccount([5]);
-    expect(newAddress.size).toBe(1);
-    expect(wallet.eoaAddressMap.size).toBe(6);
+    expect(pk0.length).toBe(32);
+    expect(pk1.length).toBe(32);
+    expect(pk2.length).toBe(32);
+
+    const hex0 = Buffer.from(pk0).toString('hex');
+    const hex1 = Buffer.from(pk1).toString('hex');
+    const hex2 = Buffer.from(pk2).toString('hex');
+    expect(hex0).not.toBe(hex1);
+    expect(hex1).not.toBe(hex2);
+    expect(hex0).not.toBe(hex2);
   });
 
-  it('example: lookup index by address for signing', async () => {
+  it('EOAAccount.getPublicKey returns different keys per index', async () => {
     const { wallet } = await createTestSeedPhraseWallet();
 
-    const addressMap = await wallet.getEOAAccount([0, 1, 2]);
+    const accounts = await wallet.getEOAAccount([0, 1]);
 
-    // Find which index owns a specific address
-    const targetAddress = addressMap.get(1)!;
-    let signingIndex: number | undefined;
-    for (const [index, addr] of wallet.eoaAddressMap) {
-      if (addr === targetAddress) {
-        signingIndex = index;
-        break;
-      }
+    const pubKey0 = await accounts[0].getPublicKey();
+    const pubKey1 = await accounts[1].getPublicKey();
+
+    // Uncompressed secp256k1: 65 bytes (0x04 prefix + 64 bytes)
+    expect(pubKey0.length).toBe(65);
+    expect(pubKey1.length).toBe(65);
+    expect(Buffer.from(pubKey0).toString('hex')).not.toBe(Buffer.from(pubKey1).toString('hex'));
+  });
+
+  // --- Usage example (matches iOS pattern) ---
+
+  it('example: derive EOAs and sign directly on each account', async () => {
+    const { wallet } = await createTestSeedPhraseWallet();
+
+    // Derive 3 EOA accounts
+    const accounts = await wallet.getEOAAccount([0, 1, 2]);
+
+    for (const account of accounts) {
+      // Each account knows its own index and address
+      expect(account.index).toBeGreaterThanOrEqual(0);
+      expect(account.address).toMatch(/^0x[0-9a-fA-F]{40}$/);
+
+      // Sign directly — no need to pass index
+      const message = '0x' + Buffer.from(`hello from EOA #${account.index}`).toString('hex');
+      const sig = await account.signPersonalMessage(message);
+      expect(sig.signature).toBeDefined();
     }
+  });
 
-    expect(signingIndex).toBe(1);
+  it('example: add more EOAs later and sign', async () => {
+    const { wallet } = await createTestSeedPhraseWallet();
 
-    // Sign with the found index (uses key from m/44'/60'/0'/0/1)
-    const message = '0x' + Buffer.from('Sign with correct key').toString('hex');
-    const signed = await wallet.ethSignPersonalMessage(message, signingIndex!);
-    expect(signed.signature).toBeDefined();
+    // Start with 2 accounts
+    const initial = await wallet.getEOAAccount([0, 1]);
+    expect(initial.length).toBe(2);
+
+    // Add index 5 later — cache merges
+    const [eoa5] = await wallet.getEOAAccount([5]);
+    expect(wallet.eoaAddressMap.size).toBe(3); // 0, 1, 5
+
+    // Sign directly on the new account
+    const message = '0x' + Buffer.from('hello from EOA #5').toString('hex');
+    const sig = await eoa5.signPersonalMessage(message);
+    expect(sig.signature).toBeDefined();
   });
 });

--- a/packages/wallet/src/__tests__/wallet-eoa.test.ts
+++ b/packages/wallet/src/__tests__/wallet-eoa.test.ts
@@ -4,10 +4,35 @@ import { WalletCoreProvider } from '../crypto/wallet-core-provider';
 import { PrivateKey } from '../keys/private-key';
 import { SeedPhraseKey } from '../keys/seed-phrase-key';
 import { MemoryStorage } from '../storage/memory-storage';
-import { NETWORKS } from '../types/key';
+import { BIP44_PATHS, NETWORKS } from '../types/key';
 import { WalletFactory } from '../wallet';
 
-describe('Wallet EOA address derivation', () => {
+// EOA derivation uses ETH BIP44 path m/44'/60'/0'/0/{index} internally
+// via WalletCoreProvider.getEVMPrivateKey(hdWallet, index).
+// This is independent from Flow's m/44'/539'/0'/0/0 path.
+
+const TEST_MNEMONIC =
+  'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
+
+/**
+ * Helper to create a SeedPhraseKey wallet for EOA testing.
+ * Uses ETH BIP44 path (m/44'/60'/0'/0/0) as base derivation path.
+ */
+async function createTestSeedPhraseWallet() {
+  const storage = new MemoryStorage();
+  const key = await SeedPhraseKey.createAdvanced(
+    {
+      mnemonic: TEST_MNEMONIC,
+      derivationPath: BIP44_PATHS.EVM, // m/44'/60'/0'/0/0
+      passphrase: '',
+    },
+    storage
+  );
+  const wallet = WalletFactory.createKeyWallet(key, new Set([NETWORKS.FLOW_EVM_MAINNET]), storage);
+  return { key, wallet, storage };
+}
+
+describe("Wallet multi-EOA (BIP44 m/44'/60'/0'/0/{index})", () => {
   // --- PrivateKey wallet (single EOA only) ---
 
   it('derives and caches the EOA address for a private key wallet', async () => {
@@ -46,26 +71,10 @@ describe('Wallet EOA address derivation', () => {
     await expect(wallet.getEOAAccount([0, 1])).rejects.toThrow();
   });
 
-  // --- SeedPhrase wallet (multi-EOA) ---
+  // --- SeedPhrase wallet: address derivation ---
 
   it('defaults to index [0] when no indexes provided', async () => {
-    const testMnemonic =
-      'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
-
-    const storage = new MemoryStorage();
-    const key = await SeedPhraseKey.createAdvanced(
-      {
-        mnemonic: testMnemonic,
-        derivationPath: "m/44'/539'/0'/0/0",
-        passphrase: '',
-      },
-      storage
-    );
-    const wallet = WalletFactory.createKeyWallet(
-      key,
-      new Set([NETWORKS.FLOW_EVM_MAINNET]),
-      storage
-    );
+    const { wallet } = await createTestSeedPhraseWallet();
 
     const addressMap = await wallet.getEOAAccount();
 
@@ -75,93 +84,37 @@ describe('Wallet EOA address derivation', () => {
   });
 
   it('derives multiple EOA addresses from a seed phrase', async () => {
-    const testMnemonic =
-      'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
+    const { wallet } = await createTestSeedPhraseWallet();
 
-    const storage = new MemoryStorage();
-    const key = await SeedPhraseKey.createAdvanced(
-      {
-        mnemonic: testMnemonic,
-        derivationPath: "m/44'/539'/0'/0/0",
-        passphrase: '',
-      },
-      storage
-    );
-    const wallet = WalletFactory.createKeyWallet(
-      key,
-      new Set([NETWORKS.FLOW_EVM_MAINNET]),
-      storage
-    );
-
-    // Derive index 0, 1, and 2
+    // Derive via ETH BIP44: m/44'/60'/0'/0/0, m/44'/60'/0'/0/1, m/44'/60'/0'/0/2
     const addressMap = await wallet.getEOAAccount([0, 1, 2]);
 
     expect(addressMap.size).toBe(3);
-    expect(addressMap.has(0)).toBe(true);
-    expect(addressMap.has(1)).toBe(true);
-    expect(addressMap.has(2)).toBe(true);
 
-    // All addresses must be different
+    // All addresses must be different (different BIP44 indexes → different keys)
     const addresses = [...addressMap.values()];
-    const uniqueAddresses = new Set(addresses);
-    expect(uniqueAddresses.size).toBe(3);
+    expect(new Set(addresses).size).toBe(3);
 
     // All should be valid checksummed Ethereum addresses
     for (const addr of addresses) {
       expect(addr).toMatch(/^0x[0-9a-fA-F]{40}$/);
     }
 
-    // eoaAddress set contains all three
     expect(wallet.eoaAddress.size).toBe(3);
   });
 
   it('returns cached addresses without re-derivation when forceRefresh is false', async () => {
-    const testMnemonic =
-      'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
+    const { wallet } = await createTestSeedPhraseWallet();
 
-    const storage = new MemoryStorage();
-    const key = await SeedPhraseKey.createAdvanced(
-      {
-        mnemonic: testMnemonic,
-        derivationPath: "m/44'/539'/0'/0/0",
-        passphrase: '',
-      },
-      storage
-    );
-    const wallet = WalletFactory.createKeyWallet(
-      key,
-      new Set([NETWORKS.FLOW_EVM_MAINNET]),
-      storage
-    );
-
-    // First call derives
     const first = await wallet.getEOAAccount([0, 1]);
-    // Second call should return same results from cache
     const second = await wallet.getEOAAccount([0, 1]);
 
     expect(second).toEqual(first);
   });
 
   it('merges new indexes into existing cache', async () => {
-    const testMnemonic =
-      'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
+    const { wallet } = await createTestSeedPhraseWallet();
 
-    const storage = new MemoryStorage();
-    const key = await SeedPhraseKey.createAdvanced(
-      {
-        mnemonic: testMnemonic,
-        derivationPath: "m/44'/539'/0'/0/0",
-        passphrase: '',
-      },
-      storage
-    );
-    const wallet = WalletFactory.createKeyWallet(
-      key,
-      new Set([NETWORKS.FLOW_EVM_MAINNET]),
-      storage
-    );
-
-    // Derive index 0
     await wallet.getEOAAccount([0]);
     expect(wallet.eoaAddressMap.size).toBe(1);
 
@@ -173,144 +126,73 @@ describe('Wallet EOA address derivation', () => {
   });
 
   it('forceRefresh re-derives even when cached', async () => {
-    const testMnemonic =
-      'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
-
-    const storage = new MemoryStorage();
-    const key = await SeedPhraseKey.createAdvanced(
-      {
-        mnemonic: testMnemonic,
-        derivationPath: "m/44'/539'/0'/0/0",
-        passphrase: '',
-      },
-      storage
-    );
-    const wallet = WalletFactory.createKeyWallet(
-      key,
-      new Set([NETWORKS.FLOW_EVM_MAINNET]),
-      storage
-    );
+    const { wallet } = await createTestSeedPhraseWallet();
 
     const first = await wallet.getEOAAccount([0]);
     const refreshed = await wallet.getEOAAccount([0], true);
 
-    // Same addresses, just re-derived
     expect(refreshed.get(0)).toBe(first.get(0));
   });
 
-  // --- Multi-EOA private key and signing tests ---
+  // --- SeedPhrase wallet: per-index key derivation (m/44'/60'/0'/0/{index}) ---
 
-  it('derives different private keys for different indexes', async () => {
-    const testMnemonic =
-      'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
+  it('derives different private keys for different ETH BIP44 indexes', async () => {
+    const { key } = await createTestSeedPhraseWallet();
 
-    const storage = new MemoryStorage();
-    const key = await SeedPhraseKey.createAdvanced(
-      {
-        mnemonic: testMnemonic,
-        derivationPath: "m/44'/539'/0'/0/0",
-        passphrase: '',
-      },
-      storage
-    );
-
-    // Get private keys for different indexes
+    // ethPrivateKey uses m/44'/60'/0'/0/{index} internally
     const pk0 = await key.ethPrivateKey(0);
     const pk1 = await key.ethPrivateKey(1);
     const pk2 = await key.ethPrivateKey(2);
 
-    // All private keys must be 32 bytes
+    // All private keys must be 32 bytes (secp256k1)
     expect(pk0.length).toBe(32);
     expect(pk1.length).toBe(32);
     expect(pk2.length).toBe(32);
 
     // All private keys must be different
-    expect(Buffer.from(pk0).toString('hex')).not.toBe(Buffer.from(pk1).toString('hex'));
-    expect(Buffer.from(pk1).toString('hex')).not.toBe(Buffer.from(pk2).toString('hex'));
-    expect(Buffer.from(pk0).toString('hex')).not.toBe(Buffer.from(pk2).toString('hex'));
+    const hex0 = Buffer.from(pk0).toString('hex');
+    const hex1 = Buffer.from(pk1).toString('hex');
+    const hex2 = Buffer.from(pk2).toString('hex');
+    expect(hex0).not.toBe(hex1);
+    expect(hex1).not.toBe(hex2);
+    expect(hex0).not.toBe(hex2);
   });
 
-  it('derives different public keys for different indexes', async () => {
-    const testMnemonic =
-      'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
-
-    const storage = new MemoryStorage();
-    const key = await SeedPhraseKey.createAdvanced(
-      {
-        mnemonic: testMnemonic,
-        derivationPath: "m/44'/539'/0'/0/0",
-        passphrase: '',
-      },
-      storage
-    );
+  it('derives different public keys for different ETH BIP44 indexes', async () => {
+    const { key } = await createTestSeedPhraseWallet();
 
     const pubKey0 = await key.ethPublicKey(0);
     const pubKey1 = await key.ethPublicKey(1);
 
-    // Uncompressed secp256k1 public keys are 65 bytes (0x04 prefix + 64 bytes)
+    // Uncompressed secp256k1 public keys: 65 bytes (0x04 prefix + 64 bytes)
     expect(pubKey0.length).toBe(65);
     expect(pubKey1.length).toBe(65);
 
-    // Must be different
     expect(Buffer.from(pubKey0).toString('hex')).not.toBe(Buffer.from(pubKey1).toString('hex'));
   });
 
-  it('produces different signatures for same message with different indexes', async () => {
-    const testMnemonic =
-      'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
+  // --- SeedPhrase wallet: per-index signing ---
 
-    const storage = new MemoryStorage();
-    const key = await SeedPhraseKey.createAdvanced(
-      {
-        mnemonic: testMnemonic,
-        derivationPath: "m/44'/539'/0'/0/0",
-        passphrase: '',
-      },
-      storage
-    );
-    const wallet = WalletFactory.createKeyWallet(
-      key,
-      new Set([NETWORKS.FLOW_EVM_MAINNET]),
-      storage
-    );
+  it('produces different signatures for same message with different indexes', async () => {
+    const { wallet } = await createTestSeedPhraseWallet();
 
     const message = '0x' + Buffer.from('Hello Flow').toString('hex');
 
-    // Sign the same message with index 0 and index 1
+    // Sign the same message with index 0 (m/44'/60'/0'/0/0) and index 1 (m/44'/60'/0'/0/1)
     const sig0 = await wallet.ethSignPersonalMessage(message, 0);
     const sig1 = await wallet.ethSignPersonalMessage(message, 1);
 
-    // Both signatures must exist
     expect(sig0.signature).toBeDefined();
     expect(sig1.signature).toBeDefined();
-
-    // Signatures must be different (different private keys)
+    // Different private keys → different signatures
     expect(sig0.signature).not.toBe(sig1.signature);
   });
 
   it('signs transaction with correct EOA index', async () => {
-    const testMnemonic =
-      'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
+    const { wallet } = await createTestSeedPhraseWallet();
 
-    const storage = new MemoryStorage();
-    const key = await SeedPhraseKey.createAdvanced(
-      {
-        mnemonic: testMnemonic,
-        derivationPath: "m/44'/539'/0'/0/0",
-        passphrase: '',
-      },
-      storage
-    );
-    const wallet = WalletFactory.createKeyWallet(
-      key,
-      new Set([NETWORKS.FLOW_EVM_MAINNET]),
-      storage
-    );
+    await wallet.getEOAAccount([0, 1]);
 
-    // Derive addresses to know which address each index maps to
-    const addressMap = await wallet.getEOAAccount([0, 1]);
-
-    // Sign a transaction with index 1
     const tx = {
       chainId: 747,
       to: '0x0000000000000000000000000000000000000001' as const,
@@ -324,32 +206,14 @@ describe('Wallet EOA address derivation', () => {
     const signed0 = await wallet.ethSignTransaction(tx, 0);
     const signed1 = await wallet.ethSignTransaction(tx, 1);
 
-    // Both must succeed
     expect(signed0.rawTransaction).toBeDefined();
     expect(signed1.rawTransaction).toBeDefined();
-
-    // Signed transactions must be different (different signing keys)
+    // Different signing keys → different raw transactions
     expect(signed0.rawTransaction).not.toBe(signed1.rawTransaction);
   });
 
   it('signs EIP-712 typed data with different indexes', async () => {
-    const testMnemonic =
-      'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
-
-    const storage = new MemoryStorage();
-    const key = await SeedPhraseKey.createAdvanced(
-      {
-        mnemonic: testMnemonic,
-        derivationPath: "m/44'/539'/0'/0/0",
-        passphrase: '',
-      },
-      storage
-    );
-    const wallet = WalletFactory.createKeyWallet(
-      key,
-      new Set([NETWORKS.FLOW_EVM_MAINNET]),
-      storage
-    );
+    const { wallet } = await createTestSeedPhraseWallet();
 
     const typedData = {
       types: {
@@ -379,63 +243,30 @@ describe('Wallet EOA address derivation', () => {
     expect(sig0.signature).not.toBe(sig1.signature);
   });
 
-  // --- Usage examples as tests ---
+  // --- Usage examples ---
 
   it('example: derive 5 EOA accounts and sign with index 2', async () => {
-    const testMnemonic =
-      'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
+    const { wallet } = await createTestSeedPhraseWallet();
 
-    const storage = new MemoryStorage();
-    const key = await SeedPhraseKey.createAdvanced(
-      {
-        mnemonic: testMnemonic,
-        derivationPath: "m/44'/539'/0'/0/0",
-        passphrase: '',
-      },
-      storage
-    );
-    const wallet = WalletFactory.createKeyWallet(
-      key,
-      new Set([NETWORKS.FLOW_EVM_MAINNET]),
-      storage
-    );
-
-    // Step 1: Derive 5 EOA addresses
+    // Derive 5 EOA addresses (m/44'/60'/0'/0/0 through m/44'/60'/0'/0/4)
     const addressMap = await wallet.getEOAAccount([0, 1, 2, 3, 4]);
     expect(addressMap.size).toBe(5);
 
-    // Step 2: Sign a personal message with index 2
+    // Sign a personal message with index 2 (uses key from m/44'/60'/0'/0/2)
     const message = '0x' + Buffer.from('Hello from EOA #2').toString('hex');
     const signed = await wallet.ethSignPersonalMessage(message, 2);
     expect(signed).toBeDefined();
     expect(signed.signature).toBeDefined();
 
-    // Step 3: Later, add index 5 without losing 0-4
+    // Add index 5 later — merges into cache
     const newAddress = await wallet.getEOAAccount([5]);
     expect(newAddress.size).toBe(1);
-    expect(wallet.eoaAddressMap.size).toBe(6); // 0-5 all cached
+    expect(wallet.eoaAddressMap.size).toBe(6);
   });
 
   it('example: lookup index by address for signing', async () => {
-    const testMnemonic =
-      'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
+    const { wallet } = await createTestSeedPhraseWallet();
 
-    const storage = new MemoryStorage();
-    const key = await SeedPhraseKey.createAdvanced(
-      {
-        mnemonic: testMnemonic,
-        derivationPath: "m/44'/539'/0'/0/0",
-        passphrase: '',
-      },
-      storage
-    );
-    const wallet = WalletFactory.createKeyWallet(
-      key,
-      new Set([NETWORKS.FLOW_EVM_MAINNET]),
-      storage
-    );
-
-    // Derive multiple EOAs
     const addressMap = await wallet.getEOAAccount([0, 1, 2]);
 
     // Find which index owns a specific address
@@ -450,7 +281,7 @@ describe('Wallet EOA address derivation', () => {
 
     expect(signingIndex).toBe(1);
 
-    // Sign with the found index
+    // Sign with the found index (uses key from m/44'/60'/0'/0/1)
     const message = '0x' + Buffer.from('Sign with correct key').toString('hex');
     const signed = await wallet.ethSignPersonalMessage(message, signingIndex!);
     expect(signed.signature).toBeDefined();

--- a/packages/wallet/src/account/eoaAccount.ts
+++ b/packages/wallet/src/account/eoaAccount.ts
@@ -7,12 +7,12 @@
  */
 
 import {
-  type EthereumKeyProtocol,
   type EthUnsignedTransaction,
   type EthSignedTransaction,
   type EthSignedMessage,
   type HexLike,
-} from '../types/key-protocol';
+} from '../services/eth-signer';
+import { type EthereumKeyProtocol } from '../types/key-protocol';
 
 export class EOAAccount {
   /** BIP44 address index (last component of m/44'/60'/0'/0/{index}) */

--- a/packages/wallet/src/account/eoaAccount.ts
+++ b/packages/wallet/src/account/eoaAccount.ts
@@ -1,0 +1,73 @@
+/**
+ * EOAAccount - a derived Ethereum account bound to a specific BIP44 index.
+ * Wraps an EthereumKeyProtocol + index so callers can sign directly
+ * without tracking which index maps to which address.
+ *
+ * Derivation path: m/44'/60'/0'/0/{index}
+ */
+
+import {
+  type EthereumKeyProtocol,
+  type EthUnsignedTransaction,
+  type EthSignedTransaction,
+  type EthSignedMessage,
+  type HexLike,
+} from '../types/key-protocol';
+
+export class EOAAccount {
+  /** BIP44 address index (last component of m/44'/60'/0'/0/{index}) */
+  readonly index: number;
+
+  /** EIP-55 checksummed Ethereum address */
+  readonly address: string;
+
+  private readonly key: EthereumKeyProtocol;
+
+  constructor(key: EthereumKeyProtocol, index: number, address: string) {
+    this.key = key;
+    this.index = index;
+    this.address = address;
+  }
+
+  /**
+   * Return the raw 32-byte secp256k1 private key for this EOA.
+   */
+  async getPrivateKey(): Promise<Uint8Array> {
+    return await this.key.ethPrivateKey(this.index);
+  }
+
+  /**
+   * Return the uncompressed secp256k1 public key (65 bytes, 0x04-prefixed).
+   */
+  async getPublicKey(): Promise<Uint8Array> {
+    return await this.key.ethPublicKey(this.index);
+  }
+
+  /**
+   * Sign a 32-byte digest using secp256k1, returns [r|s|v].
+   */
+  async sign(digest: Uint8Array): Promise<Uint8Array> {
+    return await this.key.ethSign(digest, this.index);
+  }
+
+  /**
+   * Sign an Ethereum personal message (EIP-191).
+   */
+  async signPersonalMessage(message: HexLike): Promise<EthSignedMessage> {
+    return await this.key.ethSignPersonalMessage(message, this.index);
+  }
+
+  /**
+   * Sign an Ethereum transaction.
+   */
+  async signTransaction(transaction: EthUnsignedTransaction): Promise<EthSignedTransaction> {
+    return await this.key.ethSignTransaction(transaction, this.index);
+  }
+
+  /**
+   * Sign EIP-712 typed data.
+   */
+  async signTypedData(typedData: Record<string, unknown>): Promise<EthSignedMessage> {
+    return await this.key.ethSignTypedData(typedData, this.index);
+  }
+}

--- a/packages/wallet/src/account/index.ts
+++ b/packages/wallet/src/account/index.ts
@@ -4,5 +4,6 @@
 
 export { FlowAccount } from './flowAccount';
 export { EVMAccount } from './evmAccount';
+export { EOAAccount } from './eoaAccount';
 export { COA } from './coa';
 export { ChildAccount } from './childAccount';

--- a/packages/wallet/src/index.ts
+++ b/packages/wallet/src/index.ts
@@ -20,7 +20,7 @@ export {
   type AccountsListener,
   type LoadingListener,
 } from './wallet';
-export { FlowAccount, EVMAccount, COA, ChildAccount } from './account';
+export { FlowAccount, EVMAccount, EOAAccount, COA, ChildAccount } from './account';
 
 // Key implementations - matches iOS Flow Wallet Kit key types
 export { SeedPhraseKey } from './keys/seed-phrase-key';

--- a/packages/wallet/src/wallet/wallet.ts
+++ b/packages/wallet/src/wallet/wallet.ts
@@ -5,6 +5,7 @@
 import { logger } from '@onflow/frw-utils';
 
 import { WalletTypeUtils } from './utils';
+import { EOAAccount } from '../account/eoaAccount';
 import { WalletCoreProvider } from '../crypto/wallet-core-provider';
 import { EthProvider } from '../services/eth-provider';
 import {
@@ -199,17 +200,15 @@ export class Wallet {
   }
 
   /**
-   * Derive EOA addresses for the given BIP44 indexes.
+   * Derive EOA accounts for the given BIP44 indexes (m/44'/60'/0'/0/{index}).
+   * Each returned EOAAccount can sign directly without needing to track the index.
    * Only SeedPhraseKey supports indexes > 0; PrivateKey throws for index !== 0.
    *
    * @param indexes - BIP44 address indexes to derive (default: [0])
    * @param forceRefresh - Re-derive even if cached (default: false)
-   * @returns Map of index → checksummed Ethereum address
+   * @returns Array of EOAAccount objects that can sign independently
    */
-  async getEOAAccount(
-    indexes?: number[],
-    forceRefresh: boolean = false
-  ): Promise<Map<number, string>> {
+  async getEOAAccount(indexes?: number[], forceRefresh: boolean = false): Promise<EOAAccount[]> {
     const key = this.getEthereumKey();
     if (!key) {
       throw WalletError.EthereumCapabilityMissing();
@@ -221,23 +220,19 @@ export class Wallet {
     if (!forceRefresh) {
       const allCached = normalizedIndexes.every((i) => this._eoaAddressMap.has(i));
       if (allCached) {
-        const result = new Map<number, string>();
-        for (const i of normalizedIndexes) {
-          result.set(i, this._eoaAddressMap.get(i)!);
-        }
-        return result;
+        return normalizedIndexes.map((i) => new EOAAccount(key, i, this._eoaAddressMap.get(i)!));
       }
     }
 
     // Derive addresses for requested indexes
-    const result = new Map<number, string>();
+    const accounts: EOAAccount[] = [];
     for (const index of normalizedIndexes) {
       const address = await key.ethAddress(index);
-      result.set(index, address);
       this._eoaAddressMap.set(index, address);
+      accounts.push(new EOAAccount(key, index, address));
     }
 
-    return result;
+    return accounts;
   }
 
   private getEvmAccountKey(evmNetwork: EVMNetworkConfig, address: string): string {
@@ -508,8 +503,8 @@ export class Wallet {
       return;
     }
 
-    const addressMap = await this.getEOAAccount([0]);
-    const address = addressMap.get(0);
+    const accounts = await this.getEOAAccount([0]);
+    const address = accounts[0]?.address;
     if (!address) {
       return;
     }

--- a/packages/wallet/src/wallet/wallet.ts
+++ b/packages/wallet/src/wallet/wallet.ts
@@ -52,6 +52,7 @@ export class Wallet {
 
   // Private state properties
   private accounts: Map<string, FlowAccount | EVMAccount> = new Map(); // address -> account
+  private _eoaAddressMap: Map<number, string> = new Map();
   private isLoading: boolean = false;
   private cacheStorage: StorageProtocol;
 
@@ -184,24 +185,59 @@ export class Wallet {
   }
 
   /**
-   * Get cached EOA addresses derived from current EVM accounts
+   * Get cached EOA addresses as a Set (convenience getter derived from eoaAddressMap)
    */
   get eoaAddress(): Set<string> {
-    return new Set(this.getEVMAccounts().map((account) => account.address));
+    return new Set(this._eoaAddressMap.values());
   }
 
   /**
-   * Derive and store primary EOA account for the wallet.
+   * Get cached EOA index→address mapping
    */
-  async getEOAAccount(forceRefresh: boolean = false): Promise<string[]> {
-    const address = await this.derivePrimaryEvmAddress();
-    const evmNetworks = this.getEVMNetworks();
+  get eoaAddressMap(): Map<number, string> {
+    return new Map(this._eoaAddressMap);
+  }
 
-    if (evmNetworks.length > 0) {
-      this.upsertEvmAccounts(address, evmNetworks, forceRefresh);
+  /**
+   * Derive EOA addresses for the given BIP44 indexes.
+   * Only SeedPhraseKey supports indexes > 0; PrivateKey throws for index !== 0.
+   *
+   * @param indexes - BIP44 address indexes to derive (default: [0])
+   * @param forceRefresh - Re-derive even if cached (default: false)
+   * @returns Map of index → checksummed Ethereum address
+   */
+  async getEOAAccount(
+    indexes?: number[],
+    forceRefresh: boolean = false
+  ): Promise<Map<number, string>> {
+    const key = this.getEthereumKey();
+    if (!key) {
+      throw WalletError.EthereumCapabilityMissing();
     }
 
-    return [address];
+    const normalizedIndexes = indexes && indexes.length > 0 ? indexes : [0];
+
+    // Check cache first
+    if (!forceRefresh) {
+      const allCached = normalizedIndexes.every((i) => this._eoaAddressMap.has(i));
+      if (allCached) {
+        const result = new Map<number, string>();
+        for (const i of normalizedIndexes) {
+          result.set(i, this._eoaAddressMap.get(i)!);
+        }
+        return result;
+      }
+    }
+
+    // Derive addresses for requested indexes
+    const result = new Map<number, string>();
+    for (const index of normalizedIndexes) {
+      const address = await key.ethAddress(index);
+      result.set(index, address);
+      this._eoaAddressMap.set(index, address);
+    }
+
+    return result;
   }
 
   private getEvmAccountKey(evmNetwork: EVMNetworkConfig, address: string): string {
@@ -228,15 +264,6 @@ export class Wallet {
 
       this.setAccount(accountKey, evmAccount);
     }
-  }
-
-  private async derivePrimaryEvmAddress(): Promise<string> {
-    const key = this.getEthereumKey();
-    if (!key) {
-      throw WalletError.EthereumCapabilityMissing();
-    }
-
-    return await key.ethAddress(0);
   }
 
   /**
@@ -481,7 +508,12 @@ export class Wallet {
       return;
     }
 
-    const address = await this.derivePrimaryEvmAddress();
+    const addressMap = await this.getEOAAccount([0]);
+    const address = addressMap.get(0);
+    if (!address) {
+      return;
+    }
+
     logger.info('[frw-wallet] EOA address discovered in wallet', {
       address,
       source: 'Wallet.discoverEVMAccounts',

--- a/packages/wallet/src/wallet/wallet.ts
+++ b/packages/wallet/src/wallet/wallet.ts
@@ -574,6 +574,7 @@ export class Wallet {
     const accountsData = {
       accounts: Array.from(this.accounts.entries()),
       networks: Array.from(this.networks),
+      eoaAddressMap: Array.from(this._eoaAddressMap.entries()),
       lastUpdated: Date.now(),
     };
 
@@ -660,6 +661,21 @@ export class Wallet {
     tempNetworks.forEach((network) => {
       this.networks.add(network);
     });
+
+    // Restore cached EOA address map
+    if (Array.isArray(parsed.eoaAddressMap)) {
+      this._eoaAddressMap.clear();
+      for (const entry of parsed.eoaAddressMap) {
+        if (
+          Array.isArray(entry) &&
+          entry.length === 2 &&
+          typeof entry[0] === 'number' &&
+          typeof entry[1] === 'string'
+        ) {
+          this._eoaAddressMap.set(entry[0], entry[1]);
+        }
+      }
+    }
 
     this.notifyAccountsListeners();
     return true;


### PR DESCRIPTION
## Summary

- Add multi-EOA (Externally Owned Account) support to `packages/wallet` via BIP44 derivation (`m/44'/60'/0'/0/{index}`)
- New `EOAAccount` class wraps key + index so callers can sign directly without tracking derivation indexes
- EOA addresses are cached persistently and restored across wallet instances
- Breaking change: `getEOAAccount()` now returns `EOAAccount[]` instead of a single address

## Example Usage

### Derive Multiple EOAs

```typescript
import { WalletFactory, SeedPhraseKey, MemoryStorage, BIP44_PATHS, NETWORKS } from '@onflow/frw-wallet';

// Create wallet with seed phrase
const storage = new MemoryStorage();
const key = await SeedPhraseKey.createAdvanced(
  { mnemonic: 'your mnemonic ...', derivationPath: BIP44_PATHS.EVM, passphrase: '' },
  storage
);
const wallet = WalletFactory.createKeyWallet(key, new Set([NETWORKS.FLOW_EVM_MAINNET]), storage);

// Derive EOA accounts at indexes 0, 1, 2
const accounts = await wallet.getEOAAccount([0, 1, 2]);

for (const account of accounts) {
  console.log(`EOA #${account.index}: ${account.address}`);
}
```

### Sign Messages & Transactions Directly

```typescript
// Get a single EOA
const [eoa] = await wallet.getEOAAccount([0]);

// Sign personal message (EIP-191)
const sig = await eoa.signPersonalMessage('0x48656c6c6f');

// Sign EIP-712 typed data
const typedSig = await eoa.signTypedData({
  types: { EIP712Domain: [...], Mail: [...] },
  primaryType: 'Mail',
  domain: { name: 'Example' },
  message: { contents: 'Hello' },
});

// Sign transaction
const signed = await eoa.signTransaction({
  chainId: 747,
  to: '0x...',
  value: '0x0',
  maxFeePerGas: '0x...',
  maxPriorityFeePerGas: '0x...',
});
```

### Get Raw Keys

```typescript
const [eoa] = await wallet.getEOAAccount([0]);

const privateKey = await eoa.getPrivateKey(); // 32-byte secp256k1 private key
const publicKey = await eoa.getPublicKey();   // 65-byte uncompressed public key (0x04-prefixed)
```

### Caching & Incremental Discovery

```typescript
// First call derives and caches
const initial = await wallet.getEOAAccount([0, 1]);

// Second call returns from cache (no re-derivation)
const cached = await wallet.getEOAAccount([0, 1]);

// Add new indexes — only index 2 is derived, 0 and 1 come from cache
const extended = await wallet.getEOAAccount([0, 1, 2]);

// Force re-derivation of all requested indexes
const fresh = await wallet.getEOAAccount([0, 1, 2], true);

// Access the full EOA address map
const addressMap: Map<number, string> = wallet.eoaAddressMap;
```

### PrivateKey (Single EOA Only)

```typescript
import { PrivateKey } from '@onflow/frw-wallet';

const key = await PrivateKey.create(privateKeyBytes, storage);
const wallet = WalletFactory.createKeyWallet(key, networks, storage);

// Only index 0 is supported for PrivateKey
const [eoa] = await wallet.getEOAAccount([0]);
console.log(eoa.address);

// Requesting index > 0 throws an error
await wallet.getEOAAccount([1]); // throws WalletError
```

## Test plan

- [x] 126 unit tests covering all EOA derivation, signing, caching, and persistence scenarios
- [x] `pnpm -F @onflow/frw-wallet test` passes

Closes #1334

🤖 Generated with [Claude Code](https://claude.com/claude-code)
