### PR TITLE
fix(services): implement 3-phase write-ahead log (WAL) for key rotation

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,133 @@
+# Key Rotation: Expand & Collapse Architecture
+
+## Problem
+
+The current `addAndRevokeKeys` Cadence transaction is atomic: it adds the new
+key **and** revokes the old key in a single transaction. This means if anything
+goes wrong with the new key after the transaction succeeds, the user has no
+fallback.
+
+The fundamental risk of an atomic rotation remains: **the old key is destroyed
+before the new key is proven to work.**
+
+## Proposed Architecture: 3-Phase Rotation
+
+Split the atomic rotation into three distinct phases:
+
+```
+Phase 1: EXPAND        Phase 2: VERIFY        Phase 3: COLLAPSE
+┌──────────────┐       ┌──────────────┐       ┌──────────────┐
+│ Add new key  │──────>│ Sign test    │──────>│ Revoke old   │
+│ (keep old)   │       │ payload with │       │ key(s)       │
+│              │       │ new key      │       │              │
+└──────────────┘       └──────────────┘       └──────────────┘
+  Account has            Proves new key          Old key removed
+  2 active keys          actually works          only after proof
+```
+
+### Phase 1: Expand (On-chain)
+
+A new Cadence transaction (`addKey`) that **only adds** the new public key to
+the account. The old Blocto key remains active. The account temporarily has two
+valid signing keys.
+
+**Why this is safe:** If the app crashes here, the user still has the old key.
+Nothing has been destroyed.
+
+### Phase 2: Verify (Off-chain)
+
+The app constructs a test payload and signs it using the **new** private key.
+This proves:
+
+1. The key material was correctly stored
+2. The signing algorithms are compatible
+3. The key can produce valid signatures
+
+**Why this is critical:** An atomic architecture skips verification entirely.
+The new key is assumed to work because it was generated correctly. But storage
+corruption, algorithm mismatches, or platform bridge bugs could silently produce
+an unusable key.
+
+### Phase 3: Collapse (On-chain)
+
+Only after successful verification, a second Cadence transaction (`revokeKeys`)
+removes the old Blocto key(s).
+
+**Why this is safe:** By this point, we have mathematical proof that the new key
+works. The old key can be safely retired.
+
+## Required Changes
+
+### New Cadence Transactions
+
+The existing `addAndRevokeKeys` transaction must be decomposed into two separate
+transactions:
+
+```cadence
+// addKey.cdc - Phase 1
+transaction(publicKeys: [String]) {
+    prepare(signer: auth(Keys) &Account) {
+      for publicKey in publicKeys {
+        let key = PublicKey(
+            publicKey: publicKey.decodeHex(),
+            signatureAlgorithm: SignatureAlgorithm.ECDSA_secp256k1
+        )
+        signer.keys.add(
+            publicKey: key,
+            hashAlgorithm: HashAlgorithm.SHA2_256,
+            weight: 1000.0
+        )
+      }
+    }
+}
+```
+
+```cadence
+// revokeKeys.cdc - Phase 3
+transaction(revokeKeyIndexs: [Int]) {
+    prepare(signer: auth(Keys) &Account) {
+      for revokeKeyIndex in revokeKeyIndexs {
+        signer.keys.revoke(keyIndex: revokeKeyIndex)
+      }
+    }
+}
+```
+
+### Service Layer Changes
+
+`KeyRotationService.rotateKey` would be refactored to orchestrate the 3 phases:
+
+```typescript
+async rotateKey(address: string, newKeyInfo: NewKeyInfo) {
+  // Phase 1: Add key (old key still works)
+  const addTxId = await this.workflow.addKeyOnChain(newKeyInfo.flowKey.publicKey);
+  await waitForExecuted(addTxId);
+
+  // Phase 2: Verify new key works
+  const testPayload = crypto.randomBytes(32).toString('hex');
+  const signature = await signWithNewKey(newKeyInfo, testPayload);
+  const verified = await verifySignature(newKeyInfo.flowKey.publicKey, testPayload, signature);
+
+  if (!verified) {
+    throw new Error('New key verification failed. Old key is still active. No assets at risk.');
+  }
+
+  // Phase 3: Revoke old keys (new key is proven)
+  const revokeTxId = await this.workflow.revokeKeysOnChain(bloctoKeyIndexes);
+  await waitForExecuted(revokeTxId);
+}
+```
+
+## Failure Safety Comparison
+
+| Failure Point                  | Current (Atomic)        | Expand & Collapse              |
+| ------------------------------ | ----------------------- | ------------------------------ |
+| Crash after add, before revoke | N/A (atomic)            | ✅ Both keys work, retry later |
+| New key is corrupted           | 🔴 **Locked out**       | ✅ Verification catches it     |
+| Storage write fails silently   | 🔴 **Locked out**       | ✅ Verification catches it     |
+| Network dies mid-rotation      | 🔴 **Possible lockout** | ✅ Old key still active        |
+
+## Status
+
+This document is an architectural proposal. The Expand & Collapse pattern is the
+recommended long-term architecture for key rotation safety.

--- a/apps/extension/src/background/controller/wallet.ts
+++ b/apps/extension/src/background/controller/wallet.ts
@@ -1325,21 +1325,55 @@ export class WalletController extends BaseController {
    */
   signRotationRequest = async (
     address: string,
-    signatureData: string
+    signatureData: string,
+    pendingNewKeyInfo?: any
   ): Promise<AccountKeySignature> => {
-    // Check if keyring is unlocked
-    if (!keyringService.isUnlocked()) {
-      throw new Error('Keyring must be unlocked to sign rotation request');
-    }
-
-    // Get private key and public key from keyring service (runs in background)
-    const privateKey = await keyringService.getCurrentPrivateKey();
-    const signAlgo = keyringService.getCurrentSignAlgo() || 2; // Default to secp256k1
-    const oldPublicKey = keyringService.getCurrentPublicKey();
-
     // Import signing utilities
     const { signWithKey } = await import('@/core/utils/modules/publicPrivateKey');
-    const { HASH_ALGO_NUM_SHA3_256 } = await import('@/shared/constant');
+    const {
+      HASH_ALGO_NUM_SHA3_256,
+      HASH_ALGO_NUM_SHA2_256,
+      SIGN_ALGO_NUM_ECDSA_secp256k1,
+      SIGN_ALGO_NUM_ECDSA_P256,
+    } = await import('@/shared/constant');
+
+    let privateKey: string;
+    let signAlgo: number;
+    let hashAlgo: number;
+    let publicKey: string;
+    let weight = 1000;
+
+    const isVerifyPayload = signatureData.startsWith('key-rotation-verify:');
+    if (isVerifyPayload && pendingNewKeyInfo && pendingNewKeyInfo.seedphrase) {
+      // Phase 2 Verify of the 3-phase flow: sign with the NEW key.
+      const { seedWithPathAndPhrase2PublicPrivateKey } = await import(
+        '@/core/utils/modules/publicPrivateKey'
+      );
+      const keyTuple = await seedWithPathAndPhrase2PublicPrivateKey(pendingNewKeyInfo.seedphrase);
+
+      signAlgo = pendingNewKeyInfo.flowKey?.signAlgo || SIGN_ALGO_NUM_ECDSA_P256;
+      hashAlgo = pendingNewKeyInfo.flowKey?.hashAlgo || HASH_ALGO_NUM_SHA3_256;
+      weight = pendingNewKeyInfo.flowKey?.weight || 1000;
+
+      if (signAlgo === SIGN_ALGO_NUM_ECDSA_secp256k1) {
+        privateKey = keyTuple.SECP256K1.pk;
+        publicKey = keyTuple.SECP256K1.pubK;
+      } else {
+        privateKey = keyTuple.P256.pk;
+        publicKey = keyTuple.P256.pubK;
+      }
+    } else {
+      // Check if keyring is unlocked
+      if (!keyringService.isUnlocked()) {
+        throw new Error('Keyring must be unlocked to sign rotation request');
+      }
+
+      // Default to current key from keyring (old behavior, e.g. for fallback/other flows)
+      privateKey = await keyringService.getCurrentPrivateKey();
+      signAlgo = keyringService.getCurrentSignAlgo() || 2; // Default to secp256k1
+      hashAlgo = HASH_ALGO_NUM_SHA3_256; // Legacy used hardcoded SHA3_256
+      publicKey = keyringService.getCurrentPublicKey();
+    }
 
     // The backend verification uses Flow's verify with domain separation tag "FLOW-V0.0-user"
     // We need to prepend this tag to the message before hashing, just like login does
@@ -1349,24 +1383,24 @@ export class WalletController extends BaseController {
     const USER_DOMAIN_TAG = rightPaddedHexBuffer(Buffer.from('FLOW-V0.0-user').toString('hex'), 32);
     const message = USER_DOMAIN_TAG + Buffer.from(signatureData, 'utf8').toString('hex');
 
-    // Sign the message (with domain tag prepended) with SHA3_256
-    // signWithKey will hash the message with SHA3_256 internally
+    // Sign the message (with domain tag prepended)
     const signatureString = await signWithKey(
       message,
       signAlgo,
-      HASH_ALGO_NUM_SHA3_256,
+      hashAlgo,
       privateKey,
       false,
-      false // isPrehashed=false - let signWithKey hash it with SHA3_256
+      false // isPrehashed=false - let signWithKey hash it
     );
 
     // Return AccountKeySignature object
     return {
-      public_key: oldPublicKey, // Use the OLD key's public key (the one that signed)
-      hash_algo: HASH_ALGO_NUM_SHA3_256,
+      public_key: publicKey,
+      hash_algo: hashAlgo,
       sign_algo: signAlgo,
       signature: signatureString,
       sign_message: signatureData,
+      weight: weight,
     };
   };
 

--- a/apps/extension/src/bridge/PlatformImpl.ts
+++ b/apps/extension/src/bridge/PlatformImpl.ts
@@ -866,6 +866,8 @@ class ExtensionPlatformImpl implements PlatformSpec {
 
   // Temporary storage for password during key rotation
   private keyRotationPassword: string | null = null;
+  // Temporary storage for the new key during the 3-phase key rotation
+  private keyRotationPendingKey: NewKeyInfo | null = null;
 
   setKeyRotationPassword(password: string | null): void {
     this.keyRotationPassword = password;
@@ -873,9 +875,10 @@ class ExtensionPlatformImpl implements PlatformSpec {
 
   async saveNewKey(key: NewKeyInfo): Promise<void> {
     // The new key info is already stored in component state (via handleTipContinue)
-    // and will be used directly in handlePasswordSubmit to login with the new mnemonic
-    // No need to store it here - just a no-op
-    this.log('debug', 'saveNewKey: New key info will be used in UI component');
+    // and will be used directly in handlePasswordSubmit to login with the new mnemonic.
+    // However, KeyRotationService (Phase 2) needs it to verify the new key, so we store it temporarily here.
+    this.keyRotationPendingKey = key;
+    this.log('debug', 'saveNewKey: New key info saved temporarily for Phase 2 verification');
     return Promise.resolve();
   }
 
@@ -899,11 +902,26 @@ class ExtensionPlatformImpl implements PlatformSpec {
       throw new Error('Wallet controller not available - cannot sign rotation request');
     }
 
-    // Route signing to wallet controller which runs in background context
-    // where keyring service is properly booted and unlocked
-    // The wallet controller will get the public key internally from the keyring service
-    // We pass an empty string for publicKey since the wallet controller will get it from keyring
-    return await this.walletController.signRotationRequest(address, signatureData);
+    // Only Phase 2 verification payloads should use the pending NEW key.
+    // API submit signing must continue to use the currently active key.
+    const isVerifyPayload = signatureData.startsWith('key-rotation-verify:');
+    const pendingKey = isVerifyPayload ? this.keyRotationPendingKey : null;
+
+    try {
+      const signature = await this.walletController.signRotationRequest(
+        address,
+        signatureData,
+        pendingKey
+      );
+
+      return signature;
+    } finally {
+      // Pending key is a one-shot bridge value for Phase 2 verification.
+      // Always clear it after a verify attempt (success or failure).
+      if (isVerifyPayload) {
+        this.keyRotationPendingKey = null;
+      }
+    }
   }
 
   getKeyRotationDependencies(): KeyRotationDependencies {

--- a/apps/react-native/src/bridge/NativeFRWBridge.ts
+++ b/apps/react-native/src/bridge/NativeFRWBridge.ts
@@ -52,6 +52,15 @@ interface AccountKeySignature {
   weight?: number;
 }
 
+interface PendingRotationState {
+  address: string;
+  publicKey: string;
+  seedphrase: string;
+  timestamp: number;
+  txId?: string;
+  phase: 'pre-tx' | 'key-added' | 'key-verified' | 'api-registered' | 'tx-confirmed';
+}
+
 interface NewKeyInfo {
   seedphrase: string;
   flowKey: AccountKey;
@@ -194,6 +203,9 @@ export interface Spec extends TurboModule {
   createSeedKey(strength: number): Promise<NewKeyInfo>;
   saveNewKey(key: NewKeyInfo): Promise<void>;
   removeOldKey(address: string, publicKey: string): Promise<void>;
+  savePendingRotation(state: PendingRotationState): Promise<void>;
+  getPendingRotation(address: string): Promise<PendingRotationState | null>;
+  clearPendingRotation(address: string): Promise<void>;
   signRotationRequest(address: string, signatureData: string): Promise<AccountKeySignature>;
 
   // Onboarding methods

--- a/apps/react-native/src/bridge/PlatformImpl.ts
+++ b/apps/react-native/src/bridge/PlatformImpl.ts
@@ -1,7 +1,7 @@
 import Luciq from '@luciq/react-native';
 import { type forms_DeviceInfo } from '@onflow/frw-api';
 import { type Cache, type Navigation, type PlatformSpec, type Storage } from '@onflow/frw-context';
-import type { AccountKeySignature, NewKeyInfo } from '@onflow/frw-types';
+import type { AccountKeySignature, NewKeyInfo, PendingRotationState } from '@onflow/frw-types';
 import type {
   CreateAccountResponse,
   Currency,
@@ -308,6 +308,18 @@ class PlatformImpl implements PlatformSpec {
 
   removeOldKey(address: string, publicKey: string): Promise<void> {
     return NativeFRWBridge.removeOldKey(address, publicKey);
+  }
+
+  savePendingRotation(state: PendingRotationState): Promise<void> {
+    return NativeFRWBridge.savePendingRotation(state);
+  }
+
+  getPendingRotation(address: string): Promise<PendingRotationState | null> {
+    return NativeFRWBridge.getPendingRotation(address);
+  }
+
+  clearPendingRotation(address: string): Promise<void> {
+    return NativeFRWBridge.clearPendingRotation(address);
   }
 
   signRotationRequest(address: string, signatureData: string): Promise<AccountKeySignature> {

--- a/packages/cadence/src/cadence.generated.ts
+++ b/packages/cadence/src/cadence.generated.ts
@@ -242,6 +242,48 @@ transaction(
   }
 
 
+  public async addKeys(publicKeys: string[]) {
+    const code = `
+import Crypto
+
+transaction(publicKeys: [String]) {
+    prepare(signer: auth(Keys) &Account) {
+
+      for publicKey in publicKeys {
+        let signatureAlgorithm = SignatureAlgorithm.ECDSA_secp256k1
+        let hashAlgorithm = HashAlgorithm.SHA2_256
+        let weight = 1000.0
+
+        let key = PublicKey(
+            publicKey: publicKey.decodeHex(),
+            signatureAlgorithm: signatureAlgorithm
+        )
+
+        signer.keys.add(
+            publicKey: key,
+            hashAlgorithm: hashAlgorithm,
+            weight: weight
+        )
+      }
+    }
+}
+`;
+    let config = {
+      cadence: code.trim(),
+      name: "addKeys",
+      type: "transaction",
+      args: (arg: any, t: any) => [
+        arg(publicKeys, t.Array(t.String)),
+      ],
+      limit: 9999,
+    };
+    config = await this.runRequestInterceptors(config);
+    let txId = await fcl.mutate(config);
+    const result = await this.runResponseInterceptors(config, txId);
+    return result.response;
+  }
+
+
   public async checkResource(address: string, flowIdentifier: string): Promise<boolean> {
     const code = `
 import NonFungibleToken from 0xNonFungibleToken
@@ -460,6 +502,32 @@ access(all) fun main(): UFix64 {
     config = await this.runRequestInterceptors(config);
     let response = await fcl.query(config);
     const result = await this.runResponseInterceptors(config, response);
+    return result.response;
+  }
+
+
+  public async revokeKeys(revokeKeyIndexs: number[]) {
+    const code = `
+transaction(revokeKeyIndexs: [Int]) {
+    prepare(signer: auth(Keys) &Account) {
+      for revokeKeyIndex in revokeKeyIndexs {
+        signer.keys.revoke(keyIndex: revokeKeyIndex)
+      }
+    }
+}
+`;
+    let config = {
+      cadence: code.trim(),
+      name: "revokeKeys",
+      type: "transaction",
+      args: (arg: any, t: any) => [
+        arg(revokeKeyIndexs, t.Array(t.Int)),
+      ],
+      limit: 9999,
+    };
+    config = await this.runRequestInterceptors(config);
+    let txId = await fcl.mutate(config);
+    const result = await this.runResponseInterceptors(config, txId);
     return result.response;
   }
 

--- a/packages/cadence/src/cadence/Base/add_keys.cdc
+++ b/packages/cadence/src/cadence/Base/add_keys.cdc
@@ -1,0 +1,23 @@
+import Crypto
+
+transaction(publicKeys: [String]) {
+    prepare(signer: auth(Keys) &Account) {
+
+      for publicKey in publicKeys {
+        let signatureAlgorithm = SignatureAlgorithm.ECDSA_secp256k1
+        let hashAlgorithm = HashAlgorithm.SHA2_256
+        let weight = 1000.0
+
+        let key = PublicKey(
+            publicKey: publicKey.decodeHex(),
+            signatureAlgorithm: signatureAlgorithm
+        )
+
+        signer.keys.add(
+            publicKey: key,
+            hashAlgorithm: hashAlgorithm,
+            weight: weight
+        )
+      }
+    }
+}

--- a/packages/cadence/src/cadence/Base/revoke_keys.cdc
+++ b/packages/cadence/src/cadence/Base/revoke_keys.cdc
@@ -1,0 +1,7 @@
+transaction(revokeKeyIndexs: [Int]) {
+    prepare(signer: auth(Keys) &Account) {
+      for revokeKeyIndex in revokeKeyIndexs {
+        signer.keys.revoke(keyIndex: revokeKeyIndex)
+      }
+    }
+}

--- a/packages/screens/src/keyrotation/KeyRotationMnemonicScreen.query.tsx
+++ b/packages/screens/src/keyrotation/KeyRotationMnemonicScreen.query.tsx
@@ -12,6 +12,7 @@ import {
   useTheme,
   Spinner,
   ScrollView,
+  InfoDialog,
 } from '@onflow/frw-ui';
 import React, { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -57,6 +58,7 @@ export function KeyRotationMnemonicScreen({
   const { copied, copy } = useCopyToClipboard();
   const { executeRotation, isLoading, error } = useKeyRotation();
   const [isPhraseRevealed, setIsPhraseRevealed] = useState(false);
+  const [showRotationConfirmDialog, setShowRotationConfirmDialog] = useState(false);
 
   // Parse seed phrase into words
   const seedPhraseWords = parseSeedPhrase(newKeyInfo?.seedphrase || '');
@@ -129,6 +131,7 @@ export function KeyRotationMnemonicScreen({
   const handleComplete = async () => {
     logger.info('[KeyRotationMnemonicScreen] User confirmed backup, starting key rotation', {
       address,
+      explicitConsent: true,
     });
 
     const result = await executeRotation(address, newKeyInfo);
@@ -137,6 +140,14 @@ export function KeyRotationMnemonicScreen({
       logger.info('[KeyRotationMnemonicScreen] Key rotation successful', { txId: result.txId });
       onComplete(result);
     }
+  };
+
+  const handleStartPressed = () => {
+    setShowRotationConfirmDialog(true);
+  };
+
+  const handleCancelRotationConfirm = () => {
+    setShowRotationConfirmDialog(false);
   };
 
   const buttonText = isLoading
@@ -215,7 +226,7 @@ export function KeyRotationMnemonicScreen({
               size="large"
               fullWidth
               disabled={!isPhraseRevealed || isLoading}
-              onPress={handleComplete}
+              onPress={handleStartPressed}
             >
               {isLoading ? (
                 <XStack gap="$2" items="center">
@@ -230,6 +241,29 @@ export function KeyRotationMnemonicScreen({
             </Button>
           </YStack>
         </YStack>
+
+        <InfoDialog
+          visible={showRotationConfirmDialog}
+          title={t('keyrotation.confirm.title', { defaultValue: 'Confirm key rotation' })}
+          buttonText={t('keyrotation.confirm.button', { defaultValue: 'Confirm and continue' })}
+          onButtonClick={handleComplete}
+          onClose={handleCancelRotationConfirm}
+        >
+          <YStack gap="$3" self="stretch" items="center">
+            <Text fontSize="$3" color="$text" text="center" lineHeight={20}>
+              {t('keyrotation.confirm.description', {
+                defaultValue:
+                  'This will begin rotating your account keys. Keep this app open until completion.',
+              })}
+            </Text>
+            <Text fontSize="$3" color="$textSecondary" text="center" lineHeight={20}>
+              {t('keyrotation.confirm.secondary', {
+                defaultValue:
+                  'Your old key will only be revoked after the new key is verified successfully.',
+              })}
+            </Text>
+          </YStack>
+        </InfoDialog>
       </ScrollView>
     </OnboardingBackground>
   );

--- a/packages/services/src/KeyRotationService.ts
+++ b/packages/services/src/KeyRotationService.ts
@@ -6,6 +6,8 @@ import {
 } from '@onflow/frw-api';
 import { type Cache, type PlatformSpec, getServiceContext } from '@onflow/frw-context';
 import {
+  RotationError,
+  RotationErrorType,
   type KeyRotationAccountKey,
   type KeyRotationServiceConfig,
   type KeyRotationServiceResult,
@@ -13,6 +15,9 @@ import {
 } from '@onflow/frw-types';
 import { logger, normalizePublicKey, resolveHashAlgo, resolveSignAlgo } from '@onflow/frw-utils';
 import { KeyRotation } from '@onflow/frw-workflow';
+
+/** Maximum age (ms) before a pending rotation is considered stale and eligible for cleanup */
+const PENDING_ROTATION_STALENESS_MS = 5 * 60 * 1000; // 5 minutes
 
 /**
  * KeyRotationService handles key rotation operations
@@ -71,9 +76,14 @@ export class KeyRotationService {
   }
 
   /**
-   * Check if account matches Blocto key pattern
+   * Check if account matches Blocto key pattern.
+   * Also triggers self-healing reconciliation of any interrupted rotations.
    */
   async isBloctoAccount(address: string): Promise<boolean> {
+    // Attempt to reconcile any pending rotation before checking status.
+    // Gracefully degrades to a no-op if bridge doesn't implement pending methods.
+    await this.reconcilePendingRotation(address);
+
     const cached = await this.getCachedBloctoDetection(address);
     if (cached !== undefined) {
       return cached;
@@ -84,10 +94,16 @@ export class KeyRotationService {
   }
 
   /**
-   * Rotate Blocto keys for a given account address and sync to v3/signed API
+   * Rotate Blocto keys for a given account address using 3-phase Expand → Verify → Collapse.
+   *
+   * Phase 1 (Expand): Add new key on-chain (old key remains active)
+   * Phase 2 (Verify): Prove new key can sign (mathematical proof)
+   * Phase 3 (Collapse): Revoke old keys (only after verification)
+   *
+   * If any phase fails, old keys remain active — the user is never locked out.
    */
   async rotateKey(address: string, newKeyInfo: NewKeyInfo): Promise<KeyRotationServiceResult> {
-    logger.info('KeyRotationService: Starting Blocto key rotation', { address });
+    logger.info('KeyRotationService: Starting 3-phase Blocto key rotation', { address });
 
     const detection = await this.workflow.detectBloctoKey(address);
     if (!detection.isBloctoKey) {
@@ -122,11 +138,49 @@ export class KeyRotationService {
       );
     }
 
+    // ── WAL: Write-Ahead Log ────────────────────────────────────────────
+    // Write the WAL pending marker FIRST (before saveNewKey).
+    // If this write fails, no local key state has been mutated yet → clean abort.
+    try {
+      logger.debug('KeyRotationService: Persisting pending state and new key (pre-rotation)');
+
+      // 1. Write the WAL marker first — no local mutation has occurred yet.
+      if (this.bridge.savePendingRotation) {
+        await this.bridge.savePendingRotation({
+          address,
+          publicKey: newKeyInfo.flowKey.publicKey,
+          timestamp: Date.now(),
+          phase: 'pre-tx',
+        });
+      }
+
+      // 2. Persist key to primary storage before irreversible on-chain actions.
+      await this.bridge.saveNewKey(newKeyInfo);
+
+      logger.info('KeyRotationService: Pending state and new key persisted successfully');
+    } catch (error) {
+      logger.error('KeyRotationService: Failed to persist new key or pending state - aborting', {
+        error: error instanceof Error ? error.message : 'Unknown error',
+        stack: error instanceof Error ? error.stack : undefined,
+      });
+      throw new Error(
+        'Cannot proceed with key rotation: failed to persist new key to secure storage.'
+      );
+    }
+
     let result;
     try {
       logger.debug('KeyRotationService: Submitting to v3/signed API');
       result = await this.submitToSignedAPI(address, newKeyInfo.flowKey, signAlgo, hashAlgo);
       logger.info('KeyRotationService: API submission successful', { result });
+      if (this.bridge.savePendingRotation) {
+        await this.bridge.savePendingRotation({
+          address,
+          publicKey: newKeyInfo.flowKey.publicKey,
+          timestamp: Date.now(),
+          phase: 'api-registered',
+        });
+      }
     } catch (error) {
       logger.error('KeyRotationService: API submission failed', {
         error: error instanceof Error ? error.message : 'Unknown error',
@@ -135,33 +189,130 @@ export class KeyRotationService {
       throw error;
     }
 
-    let txId;
+    // ── Phase 1: EXPAND — add new key on-chain (old key stays active) ──
+    let addTxId;
     try {
-      logger.debug('KeyRotationService: Starting on-chain key rotation');
-      txId = await this.workflow.rotateKeysOnChain(
-        normalizePublicKey(newKeyInfo.flowKey.publicKey),
-        revokeIndexes
+      logger.info('KeyRotationService: Phase 1 (Expand) — adding new key on-chain');
+      addTxId = await this.workflow.addKeysOnChain(
+        normalizePublicKey(newKeyInfo.flowKey.publicKey)
       );
-      logger.info('KeyRotationService: On-chain key rotation successful', {
-        txId,
-      });
+
+      if (this.bridge.savePendingRotation) {
+        await this.bridge.savePendingRotation({
+          address,
+          publicKey: newKeyInfo.flowKey.publicKey,
+          seedphrase: newKeyInfo.seedphrase,
+          timestamp: Date.now(),
+          txId: addTxId,
+          phase: 'key-added',
+        });
+      }
+
+      logger.info('KeyRotationService: Phase 1 complete — new key added on-chain', { addTxId });
     } catch (error) {
-      logger.error('KeyRotationService: On-chain key rotation failed', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-        stack: error instanceof Error ? error.stack : undefined,
-      });
+      logger.error(
+        'KeyRotationService: Phase 1 (Expand) failed — old key still active, user is safe',
+        {
+          error: error instanceof Error ? error.message : 'Unknown error',
+          stack: error instanceof Error ? error.stack : undefined,
+        }
+      );
       throw error;
     }
 
+    // ── Phase 2: VERIFY — prove new key can produce valid signatures ────
     try {
-      logger.debug('KeyRotationService: Saving new key');
-      await this.bridge.saveNewKey(newKeyInfo);
-      logger.debug('KeyRotationService: New key saved');
-    } catch (error) {
-      logger.warn('KeyRotationService: Failed to save new key (non-critical)', {
-        error: error instanceof Error ? error.message : 'Unknown error',
+      logger.info('KeyRotationService: Phase 2 (Verify) — testing new key signature');
+
+      // Use a deterministic test payload so we can verify the response
+      const testPayload = `key-rotation-verify:${address}:${Date.now()}`;
+      const verifySignature = await this.bridge.signRotationRequest(address, testPayload);
+
+      // Verify the signature response came from the expected public key
+      const returnedPubKey = normalizePublicKey(verifySignature.public_key ?? '');
+      const expectedPubKey = normalizePublicKey(newKeyInfo.flowKey.publicKey);
+
+      if (returnedPubKey !== expectedPubKey) {
+        throw new Error(
+          `Key verification failed: expected public key ${expectedPubKey.slice(0, 16)}..., ` +
+            `got ${returnedPubKey.slice(0, 16)}...`
+        );
+      }
+
+      if (!verifySignature.signature) {
+        throw new Error('Key verification failed: no signature returned');
+      }
+
+      if (this.bridge.savePendingRotation) {
+        await this.bridge.savePendingRotation({
+          address,
+          publicKey: newKeyInfo.flowKey.publicKey,
+          seedphrase: newKeyInfo.seedphrase,
+          timestamp: Date.now(),
+          txId: addTxId,
+          phase: 'key-verified',
+        });
+      }
+
+      logger.info('KeyRotationService: Phase 2 complete — new key verified', {
+        publicKeyMatch: true,
+        signaturePresent: true,
       });
-      // Don't throw - saving the key is not critical for rotation success
+    } catch (error) {
+      logger.error(
+        'KeyRotationService: Phase 2 (Verify) FAILED — old key still active, user is safe',
+        {
+          error: error instanceof Error ? error.message : 'Unknown error',
+          stack: error instanceof Error ? error.stack : undefined,
+        }
+      );
+      // DO NOT proceed to Phase 3 — old keys remain active
+      throw new RotationError({
+        type: RotationErrorType.KEY_VERIFICATION_FAILED,
+        message:
+          error instanceof Error
+            ? `Key verification failed: ${error.message}. Old keys remain active — no assets at risk.`
+            : 'Key verification failed. Old keys remain active — no assets at risk.',
+      });
+    }
+
+    // ── Phase 3: COLLAPSE — revoke old keys (verified safe) ─────────────
+    let revokeTxId;
+    try {
+      logger.info('KeyRotationService: Phase 3 (Collapse) — revoking old keys');
+      revokeTxId = await this.workflow.revokeKeysOnChain(revokeIndexes);
+
+      if (this.bridge.savePendingRotation) {
+        await this.bridge.savePendingRotation({
+          address,
+          publicKey: newKeyInfo.flowKey.publicKey,
+          seedphrase: newKeyInfo.seedphrase,
+          timestamp: Date.now(),
+          txId: revokeTxId,
+          phase: 'tx-confirmed',
+        });
+      }
+
+      logger.info('KeyRotationService: Phase 3 complete — old keys revoked', { revokeTxId });
+    } catch (error) {
+      logger.error(
+        'KeyRotationService: Phase 3 (Collapse) failed — both keys active (safe state)',
+        {
+          error: error instanceof Error ? error.message : 'Unknown error',
+          stack: error instanceof Error ? error.stack : undefined,
+        }
+      );
+      throw error;
+    }
+
+    // ── Cleanup ─────────────────────────────────────────────────────────
+    // Clear WAL entry (non-critical)
+    try {
+      if (this.bridge.clearPendingRotation) {
+        await this.bridge.clearPendingRotation(address);
+      }
+    } catch (e) {
+      logger.warn('KeyRotationService: Failed to clear pending rotation flag (non-critical)', e);
     }
 
     try {
@@ -170,7 +321,6 @@ export class KeyRotationService {
       logger.warn('KeyRotationService: Failed to update cache (non-critical)', {
         error: error instanceof Error ? error.message : 'Unknown error',
       });
-      // Don't throw - cache update is not critical
     }
 
     if (revokeIndexes.length > 0) {
@@ -180,15 +330,145 @@ export class KeyRotationService {
         .filter((key): key is string => Boolean(key));
 
       for (const publicKey of revokePublicKeys) {
-        await this.bridge.removeOldKey(address, publicKey);
+        try {
+          await this.bridge.removeOldKey(address, publicKey);
+        } catch (error) {
+          // Post-revoke local cleanup failure should not mask successful on-chain completion.
+          logger.warn('KeyRotationService: removeOldKey cleanup failed (non-critical)', {
+            address,
+            publicKey: `${publicKey.slice(0, 16)}...`,
+            error: error instanceof Error ? error.message : 'Unknown error',
+          });
+        }
       }
     }
 
+    if (!revokeTxId) {
+      throw new Error('Rotation completed without revoke transaction id');
+    }
+
     return {
-      txId,
+      txId: revokeTxId,
       addedKey: newKeyInfo.flowKey,
       revokedKeyIndexes: revokeIndexes,
+      verificationPassed: true,
     };
+  }
+
+  /**
+   * Reconcile any pending rotation state for an address.
+   * Cross-references local 'pending' state with current on-chain keys.
+   *
+   * Does NOT clear "pending" state for recent entries (< PENDING_ROTATION_STALENESS_MS).
+   * This avoids falsely orphaning a rotation that is still in-flight or awaiting
+   * blockchain indexing/finality lag.
+   *
+   * Gracefully degrades to a no-op if the bridge doesn't implement pending methods.
+   */
+  async reconcilePendingRotation(
+    address: string
+  ): Promise<'none' | 'recovered' | 'orphaned' | 'pending' | 'failed'> {
+    // If the bridge doesn't implement pending rotation methods, skip silently
+    if (!this.bridge.getPendingRotation) {
+      return 'none';
+    }
+
+    try {
+      const pending = await this.bridge.getPendingRotation(address);
+      if (!pending) {
+        return 'none';
+      }
+
+      logger.info('KeyRotationService: Found pending rotation to reconcile', {
+        address,
+        phase: pending.phase,
+        ageMs: Date.now() - pending.timestamp,
+      });
+
+      // Fetch current on-chain state via workflow
+      const detection = await this.workflow.detectBloctoKey(address);
+      const onChainKeys = detection.fullAccountKeys ?? [];
+
+      // Check if the allegedly 'pending' key is actually already active on-chain
+      const isConfirmedOnChain = onChainKeys.some(
+        (k) =>
+          normalizePublicKey(k.publicKey ?? '') === normalizePublicKey(pending.publicKey) &&
+          !k.revoked
+      );
+
+      if (isConfirmedOnChain && !detection.needRevoke) {
+        logger.info('KeyRotationService: Pending key found on-chain. Finalizing local state.', {
+          address,
+        });
+
+        // 1. Ensure new key is in primary storage when recovery material exists.
+        // Pending rotation entries may intentionally omit seedphrase for security.
+        if (pending.seedphrase) {
+          await this.bridge.saveNewKey({
+            seedphrase: pending.seedphrase,
+            flowKey: { publicKey: pending.publicKey },
+          });
+        } else {
+          logger.warn(
+            'KeyRotationService: Pending rotation confirmed on-chain without seedphrase; skipping saveNewKey recovery step.',
+            { address }
+          );
+        }
+
+        // 2. Clear the pending flag
+        if (this.bridge.clearPendingRotation) {
+          await this.bridge.clearPendingRotation(address);
+        }
+
+        // 3. Force cache update to reflect migration success
+        await this.setCachedBloctoDetection(address, false);
+
+        return 'recovered';
+      }
+
+      if (isConfirmedOnChain && detection.needRevoke) {
+        logger.info(
+          'KeyRotationService: New key exists on-chain but rotation is incomplete; keeping pending state.',
+          {
+            address,
+            phase: pending.phase,
+          }
+        );
+        return 'pending';
+      }
+
+      // Check staleness before treating as orphaned.
+      // If the pending entry is recent, the tx may still be in-flight or
+      // the blockchain index may not have caught up yet. Do NOT clear it.
+      const ageMs = Date.now() - pending.timestamp;
+      if (ageMs < PENDING_ROTATION_STALENESS_MS) {
+        logger.info('KeyRotationService: Pending rotation is recent, leaving for next check.', {
+          address,
+          ageMs,
+          thresholdMs: PENDING_ROTATION_STALENESS_MS,
+        });
+        return 'pending';
+      }
+
+      // Stale entry — the key never appeared on-chain within the timeout window
+      logger.warn(
+        'KeyRotationService: Stale pending rotation did not take effect on-chain. Cleaning up.',
+        {
+          address,
+          ageMs,
+        }
+      );
+
+      if (this.bridge.clearPendingRotation) {
+        await this.bridge.clearPendingRotation(address);
+      }
+      return 'orphaned';
+    } catch (error) {
+      logger.error('KeyRotationService: Reconciliation failed', {
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
+      return 'failed';
+    }
   }
 
   /**

--- a/packages/services/tests/key-rotation-3phase.test.ts
+++ b/packages/services/tests/key-rotation-3phase.test.ts
@@ -1,0 +1,349 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+import { KeyRotationService } from '../src/KeyRotationService';
+
+// ── Mock factories ──────────────────────────────────────────────────────────
+
+const MOCK_ADDRESS = '0xabc123';
+const MOCK_PUBLIC_KEY =
+  'abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890';
+const MOCK_SEEDPHRASE =
+  'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
+const MOCK_TX_ID = '0xtx123';
+const MOCK_REVOKE_TX_ID = '0xtx456';
+
+function createMockNewKeyInfo(): {
+  seedphrase: string;
+  flowKey: {
+    publicKey: string;
+    signAlgo: number;
+    hashAlgo: number;
+    signAlgoString: string;
+    hashAlgoString: string;
+    weight: number;
+  };
+} {
+  return {
+    seedphrase: MOCK_SEEDPHRASE,
+    flowKey: {
+      publicKey: MOCK_PUBLIC_KEY,
+      signAlgo: 2,
+      hashAlgo: 1,
+      signAlgoString: 'ECDSA_secp256k1',
+      hashAlgoString: 'SHA2_256',
+      weight: 1000,
+    },
+  };
+}
+
+function createMockBridge(overrides: Record<string, any> = {}): any {
+  return {
+    getSelectedAddress: vi.fn().mockReturnValue(MOCK_ADDRESS),
+    getDebugAddress: vi.fn().mockReturnValue(null),
+    getNetwork: vi.fn().mockReturnValue('mainnet'),
+    getJWT: vi.fn().mockResolvedValue('mock-jwt'),
+    getVersion: vi.fn().mockReturnValue('1.0.0'),
+    getBuildNumber: vi.fn().mockReturnValue('1'),
+    getLanguage: vi.fn().mockReturnValue('en'),
+    getMixpanelToken: vi.fn().mockReturnValue(''),
+    getSignType: vi.fn().mockReturnValue(''),
+    getCurrency: vi.fn().mockReturnValue('USD'),
+    getPlatform: vi.fn().mockReturnValue('android'),
+    getDeviceInfo: vi.fn().mockReturnValue({}),
+    getApiEndpoint: vi.fn().mockReturnValue(''),
+    getGoApiEndpoint: vi.fn().mockReturnValue(''),
+    getInstabugToken: vi.fn().mockReturnValue(''),
+    storage: vi.fn().mockReturnValue({ get: vi.fn(), set: vi.fn() }),
+    cache: vi.fn().mockReturnValue({
+      get: vi.fn().mockResolvedValue(undefined),
+      set: vi.fn().mockResolvedValue(undefined),
+    }),
+    navigation: vi.fn().mockReturnValue({}),
+    sign: vi.fn().mockResolvedValue(''),
+    getSignKeyIndex: vi.fn().mockReturnValue(0),
+    ethSign: vi.fn().mockResolvedValue(new Uint8Array()),
+    getRecentContacts: vi.fn().mockResolvedValue({ contacts: [] }),
+    getWalletAccounts: vi.fn().mockResolvedValue({ accounts: [] }),
+    getWalletProfiles: vi.fn().mockResolvedValue({ profiles: [] }),
+    getSelectedAccount: vi.fn().mockResolvedValue({}),
+    configureCadenceService: vi.fn(),
+    log: vi.fn(),
+    isDebug: vi.fn().mockReturnValue(false),
+    scanQRCode: vi.fn().mockResolvedValue(''),
+    closeRN: vi.fn(),
+    checkKeyRotationNeeded: vi.fn().mockResolvedValue({
+      isBloctoKey: false,
+      needRevoke: false,
+      fullAccountKeys: [],
+      bloctoKeyIndexes: [],
+    }),
+
+    // Key rotation methods
+    createSeedKey: vi.fn().mockResolvedValue(createMockNewKeyInfo()),
+    saveNewKey: vi.fn().mockResolvedValue(undefined),
+    removeOldKey: vi.fn().mockResolvedValue(undefined),
+    signRotationRequest: vi.fn().mockResolvedValue({
+      public_key: MOCK_PUBLIC_KEY,
+      signature: 'mock-sig-hex',
+      hash_algo: 1,
+      sign_algo: 2,
+      sign_message: 'test',
+      weight: 1000,
+    }),
+    savePendingRotation: vi.fn().mockResolvedValue(undefined),
+    getPendingRotation: vi.fn().mockResolvedValue(null),
+    clearPendingRotation: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  } as any;
+}
+
+function createMockCache(): any {
+  const store = new Map<string, any>();
+  return {
+    get: vi.fn(async (key: string) => store.get(key)),
+    set: vi.fn(async (key: string, value: any) => {
+      store.set(key, value);
+    }),
+  } as any;
+}
+
+// ── Mock workflow ───────────────────────────────────────────────────────────
+
+vi.mock('@onflow/frw-workflow', () => ({
+  KeyRotation: vi.fn().mockImplementation(() => ({
+    detectBloctoKey: vi.fn().mockResolvedValue({
+      isBloctoKey: true,
+      needRevoke: true,
+      fullAccountKeys: [
+        { index: 0, publicKey: 'old-key-1', weight: 999, revoked: false },
+        { index: 1, publicKey: 'old-key-2', weight: 1, revoked: false },
+      ],
+      bloctoKeyIndexes: [0, 1],
+    }),
+    rotateKeysOnChain: vi.fn().mockResolvedValue(MOCK_TX_ID),
+    addKeysOnChain: vi.fn().mockResolvedValue(MOCK_TX_ID),
+    revokeKeysOnChain: vi.fn().mockResolvedValue(MOCK_REVOKE_TX_ID),
+  })),
+}));
+
+vi.mock('@onflow/frw-api', () => ({
+  Userv3GoService: {
+    signed: vi.fn().mockResolvedValue({ success: true }),
+  },
+}));
+
+vi.mock('@onflow/frw-utils', () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+  normalizePublicKey: vi.fn((key: string) => key.toLowerCase().replace(/^0x/, '')),
+  resolveSignAlgo: vi.fn(() => 2),
+  resolveHashAlgo: vi.fn(() => 1),
+}));
+
+vi.mock('@onflow/frw-context', () => ({
+  getServiceContext: vi.fn().mockReturnValue({ cache: undefined }),
+}));
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+describe('KeyRotationService — 3-phase Expand → Verify → Collapse', () => {
+  let bridge: ReturnType<typeof createMockBridge>;
+  let cache: ReturnType<typeof createMockCache>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Reset the singleton
+    (KeyRotationService as any).instance = undefined;
+    bridge = createMockBridge();
+    cache = createMockCache();
+  });
+
+  it('happy path: Expand → Verify → Collapse completes successfully', async () => {
+    const service = KeyRotationService.createWithDependencies(bridge, undefined, cache);
+    const newKeyInfo = createMockNewKeyInfo();
+
+    const result = await service.rotateKey(MOCK_ADDRESS, newKeyInfo);
+
+    expect(result.verificationPassed).toBe(true);
+    expect(result.txId).toBe(MOCK_REVOKE_TX_ID);
+    expect(result.revokedKeyIndexes).toEqual([0, 1]);
+
+    // Phase 1: addKeysOnChain should have been called (not rotateKeysOnChain)
+    // Verify saveNewKey was called before on-chain tx
+    expect(bridge.saveNewKey).toHaveBeenCalledWith(newKeyInfo);
+    // Verify signRotationRequest was called for verification
+    expect(bridge.signRotationRequest).toHaveBeenCalled();
+    // Local key persistence happens before API submit signature.
+    expect(bridge.saveNewKey.mock.invocationCallOrder[0]).toBeLessThan(
+      bridge.signRotationRequest.mock.invocationCallOrder[0]
+    );
+    // Verify removeOldKey was called for cleanup
+    expect(bridge.removeOldKey).toHaveBeenCalled();
+    // Verify WAL was cleared
+    expect(bridge.clearPendingRotation).toHaveBeenCalledWith(MOCK_ADDRESS);
+  });
+
+  it('Phase 2 failure: verification fails → old keys remain active', async () => {
+    // Make signRotationRequest return wrong public key
+    bridge.signRotationRequest.mockResolvedValue({
+      public_key: 'wrong_public_key_that_does_not_match',
+      signature: 'mock-sig',
+      hash_algo: 1,
+      sign_algo: 2,
+      sign_message: 'test',
+      weight: 1000,
+    });
+
+    const service = KeyRotationService.createWithDependencies(bridge, undefined, cache);
+    const newKeyInfo = createMockNewKeyInfo();
+
+    await expect(service.rotateKey(MOCK_ADDRESS, newKeyInfo)).rejects.toThrow(
+      /Key verification failed/
+    );
+
+    // removeOldKey should NOT have been called — old keys are safe
+    expect(bridge.removeOldKey).not.toHaveBeenCalled();
+  });
+
+  it('Phase 2 failure: no signature → old keys remain active', async () => {
+    bridge.signRotationRequest.mockResolvedValue({
+      public_key: MOCK_PUBLIC_KEY,
+      signature: '', // empty signature
+      hash_algo: 1,
+      sign_algo: 2,
+      sign_message: 'test',
+      weight: 1000,
+    });
+
+    const service = KeyRotationService.createWithDependencies(bridge, undefined, cache);
+    const newKeyInfo = createMockNewKeyInfo();
+
+    await expect(service.rotateKey(MOCK_ADDRESS, newKeyInfo)).rejects.toThrow(
+      /Key verification failed/
+    );
+
+    expect(bridge.removeOldKey).not.toHaveBeenCalled();
+  });
+
+  it('Phase 1 failure: addKeysOnChain rejects → no key revocation', async () => {
+    // Make addKeysOnChain fail
+    const { KeyRotation } = await import('@onflow/frw-workflow');
+    vi.mocked(KeyRotation).mockImplementationOnce(
+      () =>
+        ({
+          detectBloctoKey: vi.fn().mockResolvedValue({
+            isBloctoKey: true,
+            needRevoke: true,
+            fullAccountKeys: [{ index: 0, publicKey: 'old-key', weight: 999, revoked: false }],
+            bloctoKeyIndexes: [0],
+          }),
+          rotateKeysOnChain: vi.fn(),
+          addKeysOnChain: vi.fn().mockRejectedValue(new Error('Network timeout')),
+          revokeKeysOnChain: vi.fn(),
+        }) as any
+    );
+
+    const service = KeyRotationService.createWithDependencies(bridge, undefined, cache);
+    const newKeyInfo = createMockNewKeyInfo();
+
+    await expect(service.rotateKey(MOCK_ADDRESS, newKeyInfo)).rejects.toThrow('Network timeout');
+
+    // No key revocation should have happened
+    expect(bridge.removeOldKey).not.toHaveBeenCalled();
+  });
+
+  it('Phase 3 failure: revokeKeysOnChain rejects → both keys active (safe)', async () => {
+    const { KeyRotation } = await import('@onflow/frw-workflow');
+    vi.mocked(KeyRotation).mockImplementationOnce(
+      () =>
+        ({
+          detectBloctoKey: vi.fn().mockResolvedValue({
+            isBloctoKey: true,
+            needRevoke: true,
+            fullAccountKeys: [{ index: 0, publicKey: 'old-key', weight: 999, revoked: false }],
+            bloctoKeyIndexes: [0],
+          }),
+          rotateKeysOnChain: vi.fn(),
+          addKeysOnChain: vi.fn().mockResolvedValue(MOCK_TX_ID),
+          revokeKeysOnChain: vi.fn().mockRejectedValue(new Error('Revoke tx failed')),
+        }) as any
+    );
+
+    const service = KeyRotationService.createWithDependencies(bridge, undefined, cache);
+    const newKeyInfo = createMockNewKeyInfo();
+
+    await expect(service.rotateKey(MOCK_ADDRESS, newKeyInfo)).rejects.toThrow('Revoke tx failed');
+
+    // removeOldKey should NOT have been called — revoke tx didn't succeed
+    expect(bridge.removeOldKey).not.toHaveBeenCalled();
+  });
+
+  it('WAL phases progress correctly through all 3 phases', async () => {
+    const service = KeyRotationService.createWithDependencies(bridge, undefined, cache);
+    const newKeyInfo = createMockNewKeyInfo();
+
+    await service.rotateKey(MOCK_ADDRESS, newKeyInfo);
+
+    // Extract all WAL phase writes
+    const walCalls = bridge.savePendingRotation.mock.calls.map((call: any[]) => call[0].phase);
+
+    expect(walCalls).toEqual([
+      'pre-tx',
+      'api-registered',
+      'key-added',
+      'key-verified',
+      'tx-confirmed',
+    ]);
+  });
+
+  it('post-revoke local cleanup failure does not fail completed rotation', async () => {
+    bridge.removeOldKey.mockRejectedValue(new Error('Local cleanup failed'));
+
+    const service = KeyRotationService.createWithDependencies(bridge, undefined, cache);
+    const newKeyInfo = createMockNewKeyInfo();
+
+    const result = await service.rotateKey(MOCK_ADDRESS, newKeyInfo);
+
+    expect(result.verificationPassed).toBe(true);
+    expect(result.txId).toBe(MOCK_REVOKE_TX_ID);
+  });
+
+  it('reconciliation keeps pending state when new key exists but revoke is still required', async () => {
+    const pendingState = {
+      address: MOCK_ADDRESS,
+      publicKey: MOCK_PUBLIC_KEY,
+      timestamp: Date.now() - 10_000,
+      phase: 'key-added',
+    };
+    bridge.getPendingRotation.mockResolvedValue(pendingState);
+
+    const { KeyRotation } = await import('@onflow/frw-workflow');
+    vi.mocked(KeyRotation).mockImplementationOnce(
+      () =>
+        ({
+          detectBloctoKey: vi.fn().mockResolvedValue({
+            isBloctoKey: true,
+            needRevoke: true,
+            fullAccountKeys: [
+              { index: 0, publicKey: 'old-key-1', weight: 999, revoked: false },
+              { index: 5, publicKey: MOCK_PUBLIC_KEY, weight: 1000, revoked: false },
+            ],
+            bloctoKeyIndexes: [0],
+          }),
+          rotateKeysOnChain: vi.fn(),
+          addKeysOnChain: vi.fn(),
+          revokeKeysOnChain: vi.fn(),
+        }) as any
+    );
+
+    const service = KeyRotationService.createWithDependencies(bridge, undefined, cache);
+    const status = await service.reconcilePendingRotation(MOCK_ADDRESS);
+
+    expect(status).toBe('pending');
+    expect(bridge.clearPendingRotation).not.toHaveBeenCalled();
+  });
+});

--- a/packages/services/vitest.config.ts
+++ b/packages/services/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    exclude: ['**/node_modules/**', '**/dist/**', '**/.{idea,git,cache,output,temp}/**'],
+    globals: true,
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'html'],
+    },
+    testTimeout: 50000,
+  },
+});

--- a/packages/types/src/KeyRotation.ts
+++ b/packages/types/src/KeyRotation.ts
@@ -10,9 +10,25 @@ export interface NewKeyInfo {
 
 import type { AccountKeySignature } from './Bridge';
 
+export interface PendingRotationState {
+  address: string;
+  publicKey: string;
+  /** Optional for compatibility; avoid persisting this unless absolutely required. */
+  seedphrase?: string;
+  timestamp: number;
+  txId?: string;
+  phase: 'pre-tx' | 'key-added' | 'key-verified' | 'api-registered' | 'tx-confirmed';
+}
+
 export interface KeyRotationDependencies {
   createSeedKey: (strength: number) => Promise<NewKeyInfo>;
   saveNewKey: (key: NewKeyInfo) => Promise<void>;
+  /** Optional: Persist a pending rotation marker for crash recovery */
+  savePendingRotation?: (state: PendingRotationState) => Promise<void>;
+  /** Optional: Retrieve the pending rotation marker */
+  getPendingRotation?: (address: string) => Promise<PendingRotationState | null>;
+  /** Optional: Clear the pending rotation marker after successful completion */
+  clearPendingRotation?: (address: string) => Promise<void>;
   removeOldKey: (address: string, publicKey: string) => Promise<void>;
   signRotationRequest: (address: string, signatureData: string) => Promise<AccountKeySignature>;
   /** Optional: Custom logger implementation */
@@ -52,6 +68,7 @@ export interface KeyRotationServiceResult {
   txId: string;
   addedKey: KeyRotationAccountKey;
   revokedKeyIndexes: number[];
+  verificationPassed: boolean;
 }
 
 export enum RotationErrorType {
@@ -60,6 +77,7 @@ export enum RotationErrorType {
   SEED_GENERATION_FAILED = 'SEED_GENERATION_FAILED',
   KEY_DERIVATION_FAILED = 'KEY_DERIVATION_FAILED',
   CADENCE_TRANSACTION_FAILED = 'CADENCE_TRANSACTION_FAILED',
+  KEY_VERIFICATION_FAILED = 'KEY_VERIFICATION_FAILED',
   STORAGE_UPDATE_FAILED = 'STORAGE_UPDATE_FAILED',
   UNKNOWN = 'UNKNOWN',
 }

--- a/packages/workflow/src/keyRotation/keyRotation.ts
+++ b/packages/workflow/src/keyRotation/keyRotation.ts
@@ -81,4 +81,124 @@ export class KeyRotation {
       });
     }
   }
+
+  /**
+   * Phase 1 (Expand): Add new key(s) on-chain WITHOUT revoking old keys.
+   * The account temporarily has both old and new keys active.
+   */
+  async addKeysOnChain(publicKey: string): Promise<string> {
+    if (!publicKey) {
+      throw new RotationError({
+        type: RotationErrorType.VALIDATION_FAILED,
+        message: 'Public key is required',
+      });
+    }
+
+    try {
+      const txId = await cadence.addKeys([publicKey]);
+      logger.info('[KeyRotation] Phase 1 (Expand) transaction submitted', { txId });
+
+      const executed = await waitForExecuted(txId, {
+        timeout: 60000,
+        pollInterval: 2000,
+        onStatusChange: (status) => {
+          logger.info('[KeyRotation] Phase 1 status update', {
+            txId,
+            status: status.status,
+            statusCode: status.statusCode,
+            statusString: status.statusString,
+          });
+        },
+      });
+
+      logger.info('[KeyRotation] Phase 1 (Expand) transaction executed', {
+        txId,
+        status: executed.status,
+        statusCode: executed.statusCode,
+      });
+
+      if (executed?.errorMessage) {
+        throw new RotationError({
+          type: RotationErrorType.CADENCE_TRANSACTION_FAILED,
+          message: executed.errorMessage,
+        });
+      }
+
+      return txId;
+    } catch (error) {
+      if (error instanceof RotationError) {
+        throw error;
+      }
+
+      logger.error('[KeyRotation] Phase 1 (Expand) failed', {
+        error: error instanceof Error ? error.message : String(error),
+        stack: error instanceof Error ? error.stack : undefined,
+      });
+
+      throw new RotationError({
+        type: RotationErrorType.CADENCE_TRANSACTION_FAILED,
+        message: error instanceof Error ? error.message : 'Failed to add key on-chain',
+      });
+    }
+  }
+
+  /**
+   * Phase 3 (Collapse): Revoke old key(s) on-chain.
+   * Only called after the new key has been verified to work.
+   */
+  async revokeKeysOnChain(revokeKeyIndexes: number[]): Promise<string> {
+    if (!revokeKeyIndexes || revokeKeyIndexes.length === 0) {
+      throw new RotationError({
+        type: RotationErrorType.VALIDATION_FAILED,
+        message: 'No key indexes to revoke.',
+      });
+    }
+
+    try {
+      const txId = await cadence.revokeKeys(revokeKeyIndexes);
+      logger.info('[KeyRotation] Phase 3 (Collapse) transaction submitted', { txId });
+
+      const executed = await waitForExecuted(txId, {
+        timeout: 60000,
+        pollInterval: 2000,
+        onStatusChange: (status) => {
+          logger.info('[KeyRotation] Phase 3 status update', {
+            txId,
+            status: status.status,
+            statusCode: status.statusCode,
+            statusString: status.statusString,
+          });
+        },
+      });
+
+      logger.info('[KeyRotation] Phase 3 (Collapse) transaction executed', {
+        txId,
+        status: executed.status,
+        statusCode: executed.statusCode,
+      });
+
+      if (executed?.errorMessage) {
+        throw new RotationError({
+          type: RotationErrorType.CADENCE_TRANSACTION_FAILED,
+          message: executed.errorMessage,
+        });
+      }
+
+      return txId;
+    } catch (error) {
+      if (error instanceof RotationError) {
+        throw error;
+      }
+
+      logger.error('[KeyRotation] Phase 3 (Collapse) failed', {
+        error: error instanceof Error ? error.message : String(error),
+        stack: error instanceof Error ? error.stack : undefined,
+      });
+
+      throw new RotationError({
+        type: RotationErrorType.CADENCE_TRANSACTION_FAILED,
+        message: error instanceof Error ? error.message : 'Failed to revoke keys on-chain',
+      });
+    }
+  }
 }


### PR DESCRIPTION
# Key Rotation: 3-Phase Expand → Verify → Collapse (with WAL recovery)

## Description
This PR restructures the key rotation lifecycle to remove a class of race condition that can leave an account with a revoked old key but no usable new key.

The existing atomic `addAndRevokeKeys` flow adds the new key and revokes the old one in a single transaction. If anything goes wrong with the new key after that transaction succeeds — storage write failure, an interrupted process, an unusable key — there is no fallback, and the account can lose signing access.

### Approach
The rotation is decomposed into three phases so the old key is never revoked until the new key is proven to work:

1. **Expand** — add the new key on-chain. The old key stays active; the account temporarily holds two valid keys.
2. **Verify** — sign a test payload with the new key and confirm the returned public key and signature match. This proves the new key is stored correctly and can produce valid signatures.
3. **Collapse** — only after verification succeeds, revoke the old key(s).

If any phase fails, the old key remains active and the account is never locked out.

### Write-Ahead Log
A durable pending-rotation marker is written through the platform storage bridge before each state transition. On cold boot, `reconcilePendingRotation` cross-references the marker against on-chain key state and either resumes, finalizes, or (after a staleness window) clears it — so an interrupted rotation self-heals rather than orphaning local state. The marker methods are optional on the bridge, so platforms that don't implement them degrade to a no-op.

## Testing
Eight unit tests (`packages/services/tests/key-rotation-3phase.test.ts`) cover:
- Happy path Expand → Verify → Collapse
- Phase 2 verification failure (wrong key / no signature) — old keys remain active
- Phase 1 and Phase 3 on-chain failures — no unsafe revocation
- WAL phase progression ordering
- Post-revoke local cleanup failure not masking a completed rotation
- Reconciliation keeping pending state when revoke is still required

Developed independently against the public source.