### PR TITLE
fix(ci): pass CWS auth via env vars (upload-cli v4 removed flags)

### DIFF
--- a/.github/workflows/extension-release.yml
+++ b/.github/workflows/extension-release.yml
@@ -149,13 +149,15 @@ jobs:
           name: FlowCore-${{ needs.build.outputs.version }}
 
       - name: Upload and publish to Chrome Web Store
+        env:
+          # chrome-webstore-upload-cli v4 removed the auth flags; env vars only (fregante/chrome-webstore-upload-cli#80)
+          EXTENSION_ID: ${{ secrets.CWS_ITEM_ID }}
+          CLIENT_ID: ${{ secrets.CWS_CLIENT_ID }}
+          CLIENT_SECRET: ${{ secrets.CWS_CLIENT_SECRET }}
+          REFRESH_TOKEN: ${{ secrets.CWS_REFRESH_TOKEN }}
         run: |
           npx -y chrome-webstore-upload-cli@4 \
-            --source "FlowCore_${{ needs.build.outputs.version }}.zip" \
-            --extension-id "${{ secrets.CWS_ITEM_ID }}" \
-            --client-id "${{ secrets.CWS_CLIENT_ID }}" \
-            --client-secret "${{ secrets.CWS_CLIENT_SECRET }}" \
-            --refresh-token "${{ secrets.CWS_REFRESH_TOKEN }}"
+            --source "FlowCore_${{ needs.build.outputs.version }}.zip"
 
   release:
     needs: [build, publish]


### PR DESCRIPTION
First release run of the new pipeline failed in the publish job:

```
Error: The --client-id, --client-secret, and --refresh-token flags are no longer supported.
Please use the CLIENT_ID, CLIENT_SECRET, and REFRESH_TOKEN environment variables instead.
See https://github.com/fregante/chrome-webstore-upload-cli/issues/80
```

`chrome-webstore-upload-cli@4` removed the auth flags; auth must come from env vars. This moves all four values (`CLIENT_ID`, `CLIENT_SECRET`, `REFRESH_TOKEN`, `EXTENSION_ID`) to a step `env:` block. Build job succeeded; only the upload invocation was broken.

After merge: re-cut `release/ext-3.1.13` on the new dev HEAD and approve the publish gate again.

Closes #1430