### PR TITLE
fix(ci): add PUBLISHER_ID for CWS API client

### DIFF
--- a/.github/workflows/extension-release.yml
+++ b/.github/workflows/extension-release.yml
@@ -152,6 +152,7 @@ jobs:
         env:
           # chrome-webstore-upload-cli v4 removed the auth flags; env vars only (fregante/chrome-webstore-upload-cli#80)
           EXTENSION_ID: ${{ secrets.CWS_ITEM_ID }}
+          PUBLISHER_ID: ${{ secrets.CWS_PUBLISHER_ID }}
           CLIENT_ID: ${{ secrets.CWS_CLIENT_ID }}
           CLIENT_SECRET: ${{ secrets.CWS_CLIENT_SECRET }}
           REFRESH_TOKEN: ${{ secrets.CWS_REFRESH_TOKEN }}


### PR DESCRIPTION
Second run of the release pipeline got past auth and failed on:

```
Error: Option "publisherId" is required
```

The `chrome-webstore-upload` APIClient (v4 line) requires `publisherId` — the newer Chrome Web Store API addresses items as `publishers/{publisherId}/items/{itemId}`. Adds `PUBLISHER_ID` from a new `CWS_PUBLISHER_ID` secret (the ID is in the devconsole URL after `/devconsole/`).

Checked the full apiConfig surface (`extensionId`, `publisherId`, `clientId`, `clientSecret`, `refreshToken`) — this is the last required value, no third iteration expected.

Closes #1430