### PR TITLE
fix(react-native): honor Content-Disposition in the iOS in-app browser

### DIFF
--- a/apps/react-native/ios/FRW.xcodeproj/project.pbxproj
+++ b/apps/react-native/ios/FRW.xcodeproj/project.pbxproj
@@ -1513,6 +1513,7 @@
 		4E617FAD2ED57AF400BF7D2C /* UsernameGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E617FAC2ED57AF400BF7D2C /* UsernameGenerator.swift */; };
 		4E617FAE2ED57AF400BF7D2C /* UsernameGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E617FAC2ED57AF400BF7D2C /* UsernameGenerator.swift */; };
 		4E617FB82ED58BA100BF7D2C /* UsernameGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62956ECEF89B409BA93BE81D /* UsernameGeneratorTests.swift */; };
+		8761E49C04E045EF971800E2 /* NavigationResponsePolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 536B25A313114E68A238B3F2 /* NavigationResponsePolicyTests.swift */; };
 		4E63A5692B8B9D1000BBD15F /* EVMEnableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E63A5682B8B9D1000BBD15F /* EVMEnableView.swift */; };
 		4E63A56A2B8B9D1000BBD15F /* EVMEnableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E63A5682B8B9D1000BBD15F /* EVMEnableView.swift */; };
 		4E63A5712B8BA1F400BBD15F /* EVMEnableViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E63A5702B8BA1F400BBD15F /* EVMEnableViewModel.swift */; };
@@ -3447,6 +3448,7 @@
 		57E9AB762CE40B2600F04CE5 /* InsufficientStorageToastView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsufficientStorageToastView.swift; sourceTree = "<group>"; };
 		57EB45702CFFC36400393FF2 /* TokenType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenType.swift; sourceTree = "<group>"; };
 		62956ECEF89B409BA93BE81D /* UsernameGeneratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UsernameGeneratorTests.swift; sourceTree = "<group>"; };
+		536B25A313114E68A238B3F2 /* NavigationResponsePolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationResponsePolicyTests.swift; sourceTree = "<group>"; };
 		6379FBBAD62B821C877C45C1 /* libPods-FRW-dev.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-FRW-dev.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		6A0137652897E7A0009BEF20 /* HalfSheetModal.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HalfSheetModal.swift; sourceTree = "<group>"; };
 		6A06CB0528AA25F400C81BE1 /* NFTUIKitListDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NFTUIKitListDataSource.swift; sourceTree = "<group>"; };
@@ -3893,6 +3895,7 @@
 				15ADAE2C28F51ECE0014B722 /* SymmetricEncryptionTests.swift */,
 				1500783D286830EF00A00109 /* FlowReferenceWalletTests.swift */,
 				62956ECEF89B409BA93BE81D /* UsernameGeneratorTests.swift */,
+				536B25A313114E68A238B3F2 /* NavigationResponsePolicyTests.swift */,
 				4E49B72F2DDDAD0D00BC0D46 /* CurrencyFormattingTests.swift */,
 			);
 			path = FRWTests;
@@ -8424,6 +8427,7 @@
 			files = (
 				4E49B7302DDDAD0D00BC0D46 /* CurrencyFormattingTests.swift in Sources */,
 				4E617FB82ED58BA100BF7D2C /* UsernameGeneratorTests.swift in Sources */,
+				8761E49C04E045EF971800E2 /* NavigationResponsePolicyTests.swift in Sources */,
 				6A19E61E2A25DE4800392206 /* SymmetricEncryptionTests.swift in Sources */,
 				6AC62B03286AEFB5000876D9 /* FlowReferenceWalletTests.swift in Sources */,
 			);

--- a/apps/react-native/ios/FRW/Modules/Browser/BrowserViewController.swift
+++ b/apps/react-native/ios/FRW/Modules/Browser/BrowserViewController.swift
@@ -420,6 +420,30 @@ extension BrowserViewController: WKNavigationDelegate {
         reloadActionBarView()
         return .allow
     }
+
+    func webView(
+        _: WKWebView,
+        decidePolicyFor navigationResponse: WKNavigationResponse
+    ) async -> WKNavigationResponsePolicy {
+        // Attachments and non-renderable responses must never be rendered inline (#1436).
+        if BrowserViewController.isAttachmentResponse(navigationResponse.response) {
+            return .cancel
+        }
+        return navigationResponse.canShowMIMEType ? .allow : .cancel
+    }
+
+    /// True if the response was served as an attachment (`Content-Disposition: attachment`).
+    /// Attachments must not be rendered inline: rendering them would execute their contents
+    /// under the serving domain's origin, enabling phishing/XSS via trusted file-hosting
+    /// domains (e.g. an HTML file uploaded to Google Drive).
+    static func isAttachmentResponse(_ response: URLResponse) -> Bool {
+        guard let httpResponse = response as? HTTPURLResponse,
+              let disposition = httpResponse.value(forHTTPHeaderField: "Content-Disposition")
+        else {
+            return false
+        }
+        return disposition.lowercased().contains("attachment")
+    }
 }
 
 // MARK: WKUIDelegate

--- a/apps/react-native/ios/FRWTests/NavigationResponsePolicyTests.swift
+++ b/apps/react-native/ios/FRWTests/NavigationResponsePolicyTests.swift
@@ -1,0 +1,79 @@
+//
+//  NavigationResponsePolicyTests.swift
+//  FRWTests
+//
+//  Tests for BrowserViewController.isAttachmentResponse(_:), which keeps
+//  attachment/intended-for-download responses from rendering inline in the
+//  in-app browser (#1436).
+//
+
+@testable import FRW_dev
+import XCTest
+
+final class NavigationResponsePolicyTests: XCTestCase {
+    private let url = URL(string: "https://files.example.com/report")!
+
+    private func makeResponse(contentType: String, disposition: String?) -> HTTPURLResponse {
+        var headers = ["Content-Type": contentType]
+        if let disposition {
+            headers["Content-Disposition"] = disposition
+        }
+        return HTTPURLResponse(
+            url: url,
+            statusCode: 200,
+            httpVersion: "HTTP/1.1",
+            headerFields: headers
+        )!
+    }
+
+    func test_htmlWithoutDisposition_isNotAttachment() {
+        // The reported case requires the attachment disposition to trigger.
+        let response = makeResponse(contentType: "text/html", disposition: nil)
+        XCTAssertFalse(BrowserViewController.isAttachmentResponse(response))
+    }
+
+    func test_attachmentDisposition_isDetected() {
+        // An HTML file a trusted host serves for download only.
+        let response = makeResponse(
+            contentType: "text/html",
+            disposition: "attachment; filename=\"page.html\""
+        )
+        XCTAssertTrue(BrowserViewController.isAttachmentResponse(response))
+    }
+
+    func test_attachmentDisposition_isCaseInsensitive() {
+        let response = makeResponse(
+            contentType: "text/html",
+            disposition: "ATTACHMENT; FILENAME=\"page.html\""
+        )
+        XCTAssertTrue(BrowserViewController.isAttachmentResponse(response))
+    }
+
+    func test_attachmentHeaderKeyLookup_isCaseInsensitive() {
+        let response = HTTPURLResponse(
+            url: url,
+            statusCode: 200,
+            httpVersion: "HTTP/1.1",
+            headerFields: ["content-disposition": "attachment"]
+        )!
+        XCTAssertTrue(BrowserViewController.isAttachmentResponse(response))
+    }
+
+    func test_inlineDisposition_isNotAttachment() {
+        let response = makeResponse(
+            contentType: "text/html",
+            disposition: "inline; filename=\"page.html\""
+        )
+        XCTAssertFalse(BrowserViewController.isAttachmentResponse(response))
+    }
+
+    func test_nonHttpResponse_isNotAttachment() {
+        let response = URLResponse(
+            url: url,
+            mimeType: "text/html",
+            expectedContentLength: 0,
+            textEncodingName: nil
+        )
+        XCTAssertFalse(BrowserViewController.isAttachmentResponse(response))
+    }
+}


### PR DESCRIPTION
## Problem

Security researcher report (Kaushik): the in-app browser ignores `Content-Disposition: attachment` and renders files inline. A standard browser downloads such responses or refuses to render them; Flow Wallet's WebView renders them, so an HTML file uploaded to a trusted file host (e.g. Google Drive, whose download URLs serve `attachment`) executes under that trusted origin inside the wallet — enabling convincing phishing (the page can trigger wallet connect/sign prompts under a trusted domain) and access to origin-bound state in the app's webview data store.

Root cause confirmed in code: `BrowserViewController`'s `WKNavigationDelegate` only implemented request-side policy (`decidePolicyFor navigationAction` → always `.allow`); no response-side policy existed anywhere in the iOS codebase.

## Fix

- Implement `decidePolicyFor navigationResponse`: `.cancel` for attachment responses and non-renderable MIME types (`navigationResponse.canShowMIMEType`, Apple's documented pattern), `.allow` otherwise.
- The attachment check is a static helper (`isAttachmentResponse`) — header lookup and value matching are case-insensitive.

## Tests

- New `NavigationResponsePolicyTests` (6 cases): attachment detected, case-insensitive value, case-insensitive header key, inline allowed, no-disposition allowed, non-HTTP response.
- The helper logic was compiled and executed standalone (all 6 pass). Note: `canShowMIMEType` is iOS-only API, so the full target compiles under the iOS build (Xcode Cloud), not the JS CI here.
- The test file was added to the FRWTests target in project.pbxproj (entries cloned from an existing test file; fresh UUIDs).

## Out of scope (possible follow-up)

Actual download UX (`.download` + `WKDownloadDelegate` + share sheet) — currently attachments are blocked rather than downloaded, matching the safe half of standard browser behavior.

Closes #1436